### PR TITLE
Add a method to fully reconstruct a Note

### DIFF
--- a/src/note.rs
+++ b/src/note.rs
@@ -228,7 +228,7 @@ impl Note {
     }
 
     /// Reconstruct a Note from its individual fields.
-    pub fn reconstruct(
+    pub fn from_fields(
         note_type: NoteType,
         value_commitment: JubJubExtended,
         nonce: JubJubScalar,


### PR DESCRIPTION
This method is specifically needed in order
to be able to decode Notes from protocol
buffers.

Fixes #10