### PR TITLE
Add Crossover and Fee structures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2018"
 [dependencies]
 rand = "^0.7"
 kelvin = "0.19"
-poseidon252 = { git = "https://github.com/dusk-network/Poseidon252", tag = "v0.8.0" }
-dusk-pki = { git = "https://github.com/dusk-network/dusk-pki", tag = "v0.2.0"}
+poseidon252 = { git = "https://github.com/dusk-network/Poseidon252", tag = "v0.8.1" }
+dusk-pki = { git = "https://github.com/dusk-network/dusk-pki", tag = "v0.2.0" }
 thiserror = "1.0"
+dusk-plonk = { version = "0.2.11", features = ["trace-print"] }
 
-[dependencies.dusk-plonk]
-version = "0.2.11"
-features = ["trace-print"]
+[dev-dependencies]
+assert_matches = "1.3"
 
 [profile.release]
 opt-level = 3

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use crate::fee::Remainder;
+use crate::{Crossover, Error, Fee, Note, NoteType};
+use dusk_pki::SecretSpendKey;
+
+use std::convert::TryFrom;
+
+impl From<(Fee, Crossover)> for Note {
+    fn from((fee, crossover): (Fee, Crossover)) -> Note {
+        let Fee {
+            stealth_address, ..
+        } = fee;
+        let Crossover {
+            value_commitment,
+            nonce,
+            encrypted_data,
+            ..
+        } = crossover;
+
+        let note_type = NoteType::Obfuscated;
+        let pos = 0;
+
+        Note {
+            note_type,
+            value_commitment,
+            nonce,
+            stealth_address,
+            pos,
+            encrypted_data,
+        }
+    }
+}
+
+impl TryFrom<Note> for (Fee, Crossover) {
+    type Error = Error;
+
+    fn try_from(note: Note) -> Result<Self, Self::Error> {
+        match note.note_type {
+            NoteType::Obfuscated => {
+                let gas_limit = 0;
+                let gas_price = 0;
+                let Note {
+                    stealth_address,
+                    value_commitment,
+                    nonce,
+                    encrypted_data,
+                    ..
+                } = note;
+
+                Ok((
+                    Fee {
+                        gas_limit,
+                        gas_price,
+                        stealth_address,
+                    },
+                    Crossover {
+                        value_commitment,
+                        nonce,
+                        encrypted_data,
+                    },
+                ))
+            }
+            _ => Err(Error::InvalidNoteConversion),
+        }
+    }
+}
+
+impl From<Remainder> for Note {
+    fn from(remainder: Remainder) -> Note {
+        let ssk = SecretSpendKey::default();
+        let psk = ssk.public_key();
+
+        let mut note = Note::transparent(&psk, remainder.gas_changes);
+
+        note.stealth_address = remainder.stealth_address;
+
+        note
+    }
+}

--- a/src/crossover.rs
+++ b/src/crossover.rs
@@ -1,0 +1,104 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! Fee module contains the logic related to `Crossover` structure
+
+use std::io::{self, Read, Write};
+
+use dusk_pki::jubjub_decode;
+
+use poseidon252::cipher::PoseidonCipher;
+use poseidon252::sponge::sponge::sponge_hash;
+
+use poseidon252::cipher::ENCRYPTED_DATA_SIZE;
+
+use crate::{BlsScalar, Error, JubJubAffine, JubJubExtended, JubJubScalar};
+
+/// Crossover structure containing obfuscated encrypted data
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Crossover {
+    pub(crate) value_commitment: JubJubExtended,
+    pub(crate) nonce: JubJubScalar,
+    pub(crate) encrypted_data: PoseidonCipher,
+}
+
+impl PartialEq for Crossover {
+    fn eq(&self, other: &Self) -> bool {
+        self.hash() == other.hash()
+    }
+}
+
+impl Eq for Crossover {}
+
+impl Read for Crossover {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut buf = io::BufWriter::new(&mut buf[..]);
+        let mut n = 0;
+
+        n += buf.write(
+            &JubJubAffine::from(&self.value_commitment).to_bytes()[..],
+        )?;
+        n += buf.write(&self.nonce.to_bytes())?;
+        n += buf.write(&self.encrypted_data.to_bytes())?;
+
+        buf.flush()?;
+        Ok(n)
+    }
+}
+
+impl Write for Crossover {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut buf = io::BufReader::new(&buf[..]);
+
+        let mut one_scalar = [0u8; 32];
+        let mut one_cipher = [0u8; ENCRYPTED_DATA_SIZE];
+        let mut n = 0;
+
+        buf.read_exact(&mut one_scalar)?;
+        n += one_scalar.len();
+        self.value_commitment =
+            JubJubExtended::from(jubjub_decode::<JubJubAffine>(&one_scalar)?);
+
+        buf.read_exact(&mut one_scalar)?;
+        n += one_scalar.len();
+        self.nonce = jubjub_decode::<JubJubScalar>(&one_scalar)?;
+
+        buf.read_exact(&mut one_cipher)?;
+        n += one_cipher.len();
+        self.encrypted_data = PoseidonCipher::from_bytes(&one_cipher)
+            .ok_or(Error::InvalidCipher)?;
+
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Crossover {
+    /// Returns a hash represented by `H(value_commitment)`
+    pub fn hash(&self) -> BlsScalar {
+        let value_commitment = self.value_commitment().to_hash_inputs();
+
+        sponge_hash(&value_commitment)
+    }
+
+    /// Returns the Nonce used for the encrypt / decrypt of data for this note
+    pub fn nonce(&self) -> &JubJubScalar {
+        &self.nonce
+    }
+
+    /// Returns the value commitment `H(value, blinding_factor)`
+    pub fn value_commitment(&self) -> &JubJubExtended {
+        &self.value_commitment
+    }
+
+    /// Returns the encrypted data
+    pub fn encrypted_data(&self) -> &PoseidonCipher {
+        &self.encrypted_data
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,8 @@
 use std::io;
 use thiserror::Error;
 
+/// All possible errors for Phoenix's Core
+#[allow(missing_docs)]
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Invalid u8 as Note Type (expected `0` or `1`, found {0}")]
@@ -17,6 +19,8 @@ pub enum Error {
     InvalidCipher,
     #[error("ViewKey required for decrypt data from Obfuscated Note")]
     MissingViewKey,
+    #[error("Invalid Note Type for conversion")]
+    InvalidNoteConversion,
     #[error("Invalid I/O")]
     Io(#[from] io::Error),
     #[error(transparent)]

--- a/src/fee.rs
+++ b/src/fee.rs
@@ -1,0 +1,145 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! Fee module contains the logic related to `Fee` and `Remainder` structure
+
+use std::io::{self, Read, Write};
+
+use dusk_pki::Ownable;
+use dusk_pki::{PublicSpendKey, StealthAddress};
+
+use poseidon252::sponge::sponge::sponge_hash;
+
+use crate::{BlsScalar, JubJubScalar};
+
+mod remainder;
+pub use remainder::Remainder;
+
+/// The Fee structure
+#[derive(Clone, Copy, Debug)]
+pub struct Fee {
+    /// The gas limit set for the fee
+    pub gas_limit: u64,
+    /// the gas price set for the fee
+    pub gas_price: u64,
+    pub(crate) stealth_address: StealthAddress,
+}
+
+impl PartialEq for Fee {
+    fn eq(&self, other: &Self) -> bool {
+        self.hash() == other.hash()
+    }
+}
+
+impl Eq for Fee {}
+
+impl Default for Fee {
+    fn default() -> Self {
+        Fee::new(0, 0, &PublicSpendKey::default())
+    }
+}
+
+impl Read for Fee {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut buf = io::BufWriter::new(&mut buf[..]);
+        let mut n = 0;
+
+        n += buf.write(&self.gas_limit.to_le_bytes())?;
+        n += buf.write(&self.gas_price.to_le_bytes())?;
+        n += buf.write(&self.stealth_address.to_bytes())?;
+
+        buf.flush()?;
+        Ok(n)
+    }
+}
+
+impl Write for Fee {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut buf = io::BufReader::new(&buf[..]);
+
+        let mut one_u64 = [0u8; 8];
+        let mut one_stealth_address = [0u8; 64];
+        let mut n = 0;
+
+        buf.read_exact(&mut one_u64)?;
+        n += one_u64.len();
+        self.gas_limit = u64::from_le_bytes(one_u64);
+
+        buf.read_exact(&mut one_u64)?;
+        n += one_u64.len();
+        self.gas_price = u64::from_le_bytes(one_u64);
+
+        buf.read_exact(&mut one_stealth_address)?;
+        n += one_stealth_address.len();
+        self.stealth_address =
+            StealthAddress::from_bytes(&one_stealth_address)?;
+
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Fee {
+    /// Create a new Fee with inner randomness
+    pub fn new(gas_limit: u64, gas_price: u64, psk: &PublicSpendKey) -> Self {
+        let r = JubJubScalar::random(&mut rand::thread_rng());
+
+        Self::deterministic(gas_limit, gas_price, &r, psk)
+    }
+
+    /// Create a new Fee without inner randomness
+    pub fn deterministic(
+        gas_limit: u64,
+        gas_price: u64,
+        r: &JubJubScalar,
+        psk: &PublicSpendKey,
+    ) -> Self {
+        let stealth_address = psk.gen_stealth_address(r);
+
+        Fee {
+            gas_limit,
+            gas_price,
+            stealth_address,
+        }
+    }
+
+    /// Return a hash represented by `H(gas_limit, gas_price, H([pskr]))`
+    pub fn hash(&self) -> BlsScalar {
+        let pk_r = self.stealth_address().pk_r().to_hash_inputs();
+
+        sponge_hash(&[
+            BlsScalar::from(self.gas_limit),
+            BlsScalar::from(self.gas_price),
+            pk_r[0],
+            pk_r[1],
+        ])
+    }
+
+    /// Generates a remainder from the fee and the given gas consumed
+    pub fn gen_remainder(&self, gas_consumed: u64) -> Remainder {
+        // Consuming more gas than the limit provided should never
+        // occur, and it's not responsability of the `Remainder` to do
+        // check that.
+        // Here defensively ensure it's not panicking, capping the gas
+        // consumed to the gas limit.
+        let gas_consumed = std::cmp::min(gas_consumed, self.gas_limit);
+        let gas_changes = (self.gas_limit - gas_consumed) * self.gas_price;
+
+        Remainder {
+            gas_changes,
+            stealth_address: self.stealth_address,
+        }
+    }
+}
+
+impl Ownable for Fee {
+    fn stealth_address(&self) -> &StealthAddress {
+        &self.stealth_address
+    }
+}

--- a/src/fee/remainder.rs
+++ b/src/fee/remainder.rs
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! Remainder module contains the logic related to `Remainder` structure
+
+use dusk_pki::Ownable;
+use dusk_pki::StealthAddress;
+
+use poseidon252::sponge::sponge::sponge_hash;
+
+use crate::BlsScalar;
+
+/// The Remainder structure.
+#[derive(Clone, Copy, Debug)]
+pub struct Remainder {
+    /// The gas_changes set for the remainder
+    pub(crate) gas_changes: u64,
+    /// The stealth address
+    pub(crate) stealth_address: StealthAddress,
+}
+
+impl PartialEq for Remainder {
+    fn eq(&self, other: &Self) -> bool {
+        self.hash() == other.hash()
+    }
+}
+
+impl Eq for Remainder {}
+
+impl Remainder {
+    /// Return a hash represented by `H(gas, H([pskr]))`
+    pub fn hash(&self) -> BlsScalar {
+        let pk_r = self.stealth_address().pk_r().to_hash_inputs();
+
+        sponge_hash(&[BlsScalar::from(self.gas_changes), pk_r[0], pk_r[1]])
+    }
+}
+
+impl Ownable for Remainder {
+    fn stealth_address(&self) -> &StealthAddress {
+        &self.stealth_address
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,14 +4,25 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-#![allow(non_snake_case)]
+//! Phoenix's Core library types and behaviors
 
+#![allow(non_snake_case)]
+#![deny(missing_docs)]
+
+/// Type's Conversion module
+mod convert;
+/// Crossover
+pub mod crossover;
 /// Phoenix's Core Errors
 pub mod error;
+/// Fee
+pub mod fee;
 /// Transparent and Obfuscated Notes
 pub mod note;
 
+pub use crossover::Crossover;
 pub use error::Error;
+pub use fee::Fee;
 pub use note::{Note, NoteType};
 
 use dusk_plonk::bls12_381::Scalar as BlsScalar;

--- a/src/note.rs
+++ b/src/note.rs
@@ -21,9 +21,12 @@ use crate::{BlsScalar, Error, JubJubAffine, JubJubExtended, JubJubScalar};
 
 use poseidon252::cipher::{CIPHER_SIZE, ENCRYPTED_DATA_SIZE};
 
+/// The types of a Note
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum NoteType {
+    /// Defines a Transparent type of Note
     Transparent = 0,
+    /// Defines an Obfuscated type of Note
     Obfuscated = 1,
 }
 
@@ -50,12 +53,12 @@ impl TryFrom<i32> for NoteType {
 /// A note that does not encrypt its value
 #[derive(Clone, Copy, Debug)]
 pub struct Note {
-    note_type: NoteType,
-    value_commitment: JubJubExtended,
-    nonce: JubJubScalar,
-    stealth_address: StealthAddress,
-    pos: u64,
-    encrypted_data: PoseidonCipher,
+    pub(crate) note_type: NoteType,
+    pub(crate) value_commitment: JubJubExtended,
+    pub(crate) nonce: JubJubScalar,
+    pub(crate) stealth_address: StealthAddress,
+    pub(crate) pos: u64,
+    pub(crate) encrypted_data: PoseidonCipher,
 }
 
 impl PartialEq for Note {


### PR DESCRIPTION
- Add also a `Remainder` structure used internally to convert a `Fee`
  with consumed gas into a Transparent note
- Update kelvin from `v0.18` to `v0.19`
- Update poseidon252 from `v0.8.0` to `v0.8.1`
- Update dusk-pki from `v0.1.1` to `v0.2.0`
- Update dusk-plonk from `v0.2.7` to `v0.2.11`

Resolves: #19