### PR TITLE
Add `Note::transparent_stealth` function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.16.0-rc.0"
+version = "0.16.0-rc.1"
 authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network"]
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix-core"

--- a/src/note.rs
+++ b/src/note.rs
@@ -103,6 +103,39 @@ impl Note {
         Self::new(rng, NoteType::Transparent, psk, value, TRANSPARENT_BLINDER)
     }
 
+    /// Creates a new transparent note
+    ///
+    /// This is equivalent to [`transparent`] but taking only a stealth address,
+    /// a value, and a nonce. This is done to be able to generate a note
+    /// directly for a stealth address, as opposed to a public spend key.
+    pub fn transparent_stealth(
+        stealth_address: StealthAddress,
+        value: u64,
+        nonce: BlsScalar,
+    ) -> Self {
+        let value_commitment = JubJubScalar::from(value);
+        let value_commitment = (GENERATOR_EXTENDED * value_commitment)
+            + (GENERATOR_NUMS_EXTENDED * TRANSPARENT_BLINDER);
+
+        let pos = u64::MAX;
+
+        let zero = TRANSPARENT_BLINDER.into();
+        let mut encrypted_data = [zero; PoseidonCipher::cipher_size()];
+
+        encrypted_data[0] = BlsScalar::from(value);
+
+        let encrypted_data = PoseidonCipher::new(encrypted_data);
+
+        Note {
+            note_type: NoteType::Transparent,
+            value_commitment,
+            nonce,
+            stealth_address,
+            pos,
+            encrypted_data,
+        }
+    }
+
     /// Creates a new obfuscated note
     ///
     /// The provided blinding factor will be used to calculate the value

--- a/tests/note_test.rs
+++ b/tests/note_test.rs
@@ -28,6 +28,28 @@ fn transparent_note() -> Result<(), Error> {
 }
 
 #[test]
+fn transparent_stealth_note() -> Result<(), Error> {
+    let rng = &mut OsRng;
+
+    let ssk = SecretSpendKey::random(rng);
+    let psk = ssk.public_spend_key();
+
+    let r = JubJubScalar::random(rng);
+
+    let sa = psk.gen_stealth_address(&r);
+    let nonce = BlsScalar::random(rng);
+    let value = 25;
+
+    let note = Note::transparent_stealth(sa, value, nonce);
+
+    assert_eq!(note.note(), NoteType::Transparent);
+    assert_eq!(value, note.value(None)?);
+    assert_eq!(sa, *note.stealth_address());
+
+    Ok(())
+}
+
+#[test]
 fn obfuscated_note() -> Result<(), Error> {
     let rng = &mut OsRng;
 


### PR DESCRIPTION
The function allows the generation of a note by using just a stealth address, a value, and a nonce, in contrast with `Note::transparent` which requires a public spend key. This is required for environments where knowledge of the public spend key is undesirable, but a stealth address is acceptable.

This will be invaluable for the implementation of [this issue](https://github.com/dusk-network/rusk/issues/614).