### PR TITLE
Update `dusk-poseidon` dependency to `0.28`

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -44,7 +44,7 @@ jobs:
           command: test
           args: --release
 
-  test_nightly_canon:
+  test_nightly_rkyv:
     name: Nightly tests
     runs-on: ubuntu-latest
     steps:
@@ -55,7 +55,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --features canon
+          args: --release --features rkyv-impl
 
   fmt:
     name: Rustfmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `Error::Decryption` variant [#114]
+
+### Changed
+
+- Update `dusk-poseidon` from `0.26` to `0.28` [#114]
+
+### Removed
+
+- Remove `canon` feature [#114]
+- Remove `Error::PoseidonError` variant [#114]
+
 ## [0.17.1] - 2022-10-19
 
 ### Added
@@ -158,6 +171,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removal of anyhow error implementation.
 - Canonical implementation shielded by feature.
 
+[#114]: https://github.com/dusk-network/phoenix-core/issues/114
 [#107]: https://github.com/dusk-network/phoenix-core/issues/107
 [#96]: https://github.com/dusk-network/phoenix-core/issues/96
 [#94]: https://github.com/dusk-network/phoenix-core/issues/94

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ bytecheck = { version = "0.6", optional = true, default-features = false }
 [dev-dependencies]
 assert_matches = "1.3"
 rand = "0.8"
+rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
 
 [features]
 rkyv-impl = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,8 @@ rand_core = { version = "0.6", default-features = false }
 dusk-bytes = "0.1"
 dusk-bls12_381 = { version = "0.11", default-features = false }
 dusk-jubjub = { version = "0.12", default-features = false }
-dusk-poseidon = { version = "0.26", default-features = false }
+dusk-poseidon = { version = "0.28", default-features = false }
 dusk-pki = { version = "0.11", default-features = false }
-canonical = { version = "0.7", optional = true }
-canonical_derive = { version = "0.7", optional = true }
 rkyv = { version = "0.7", optional = true, default-features = false }
 bytecheck = { version = "0.6", optional = true, default-features = false }
 
@@ -25,12 +23,6 @@ assert_matches = "1.3"
 rand = "0.8"
 
 [features]
-canon = [
-    "canonical",
-    "canonical_derive",
-    "dusk-poseidon/canon",
-    "dusk-pki/canon"
-]
 rkyv-impl = [
     "dusk-poseidon/rkyv-impl",
     "dusk-jubjub/rkyv-impl",

--- a/src/crossover.rs
+++ b/src/crossover.rs
@@ -8,9 +8,6 @@
 
 use crate::{BlsScalar, JubJubExtended};
 
-#[cfg(feature = "canon")]
-use canonical_derive::Canon;
-
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
 use dusk_jubjub::JubJubAffine;
 use dusk_poseidon::cipher::PoseidonCipher;
@@ -21,7 +18,6 @@ use rkyv::{Archive, Deserialize, Serialize};
 
 /// Crossover structure containing obfuscated encrypted data
 #[derive(Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "canon", derive(Canon))]
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Serialize, Deserialize),

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,10 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_bytes::{BadLength, Error as DuskBytesError, InvalidChar};
-use dusk_poseidon::Error as PoseidonError;
-
 use core::fmt;
+use dusk_bytes::{BadLength, Error as DuskBytesError, InvalidChar};
 
 /// All possible errors for Phoenix's Core
 #[allow(missing_docs)]
@@ -27,24 +25,18 @@ pub enum Error {
     InvalidCrossoverConversion,
     /// Invalid Fee for conversion
     InvalidFeeConversion,
-    /// Poseidon Error
-    PoseidonError(PoseidonError),
+    /// Failure to decrypt
+    Decryption,
     /// Invalid Value Commitment
     InvalidCommitment,
     /// Invalid Nonce
     InvalidNonce,
     /// Dusk-bytes InvalidData error
     InvalidData,
-    /// Dusk-bytes BadLenght error
-    BadLenght(usize, usize),
+    /// Dusk-bytes BadLength error
+    BadLength(usize, usize),
     /// Dusk-bytes InvalidChar error
     InvalidChar(char, usize),
-}
-
-impl From<PoseidonError> for Error {
-    fn from(p: PoseidonError) -> Self {
-        Self::PoseidonError(p)
-    }
 }
 
 impl fmt::Display for Error {
@@ -57,7 +49,7 @@ impl From<Error> for DuskBytesError {
     fn from(err: Error) -> Self {
         match err {
             Error::InvalidData => DuskBytesError::InvalidData,
-            Error::BadLenght(found, expected) => {
+            Error::BadLength(found, expected) => {
                 DuskBytesError::BadLength { found, expected }
             }
             Error::InvalidChar(ch, index) => {
@@ -70,7 +62,7 @@ impl From<Error> for DuskBytesError {
 
 impl BadLength for Error {
     fn bad_length(found: usize, expected: usize) -> Self {
-        Error::BadLenght(found, expected)
+        Error::BadLength(found, expected)
     }
 }
 

--- a/src/fee.rs
+++ b/src/fee.rs
@@ -11,9 +11,6 @@ use dusk_pki::{Ownable, PublicSpendKey, StealthAddress};
 use dusk_poseidon::sponge::hash;
 use rand_core::{CryptoRng, RngCore};
 
-#[cfg(feature = "canon")]
-use canonical_derive::Canon;
-
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize, Serialize};
 
@@ -26,7 +23,6 @@ pub use remainder::Remainder;
 
 /// The Fee structure
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "canon", derive(Canon))]
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Serialize, Deserialize),

--- a/src/fee/remainder.rs
+++ b/src/fee/remainder.rs
@@ -9,9 +9,6 @@
 use dusk_pki::Ownable;
 use dusk_pki::StealthAddress;
 
-#[cfg(feature = "canon")]
-use canonical_derive::Canon;
-
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize, Serialize};
 
@@ -21,7 +18,6 @@ use crate::BlsScalar;
 
 /// The Remainder structure.
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "canon", derive(Canon))]
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Serialize, Deserialize),

--- a/src/message.rs
+++ b/src/message.rs
@@ -6,9 +6,6 @@
 
 use crate::{BlsScalar, Error, JubJubExtended, JubJubScalar, Note, NoteType};
 
-#[cfg(feature = "canon")]
-use canonical_derive::Canon;
-
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize, Serialize};
 
@@ -21,7 +18,6 @@ use rand_core::{CryptoRng, RngCore};
 
 /// Message structure with value commitment
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "canon", derive(Canon))]
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Serialize, Deserialize),
@@ -119,7 +115,10 @@ impl Message {
         let shared_secret = dhke(r, psk.A());
         let nonce = self.nonce;
 
-        let data = self.encrypted_data.decrypt(&shared_secret, &nonce)?;
+        let data = self
+            .encrypted_data
+            .decrypt(&shared_secret, &nonce)
+            .ok_or(Error::Decryption)?;
 
         let value = data[0].reduce();
         let value = value.0[0];

--- a/src/note.rs
+++ b/src/note.rs
@@ -15,11 +15,6 @@ use dusk_poseidon::cipher::PoseidonCipher;
 use dusk_poseidon::sponge::hash;
 use rand_core::{CryptoRng, RngCore};
 
-#[cfg(feature = "canon")]
-use canonical::Canon;
-#[cfg(feature = "canon")]
-use canonical_derive::Canon;
-
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize, Serialize};
 
@@ -30,7 +25,6 @@ pub(crate) const TRANSPARENT_BLINDER: JubJubScalar = JubJubScalar::zero();
 
 /// The types of a Note
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "canon", derive(Canon))]
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Serialize, Deserialize),
@@ -65,7 +59,6 @@ impl TryFrom<i32> for NoteType {
 
 /// A note that does not encrypt its value
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "canon", derive(Canon))]
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Serialize, Deserialize),
@@ -224,7 +217,7 @@ impl Note {
         let data = self
             .encrypted_data
             .decrypt(&shared_secret, &self.nonce)
-            .map_err(|_| BytesError::InvalidData)?;
+            .ok_or(BytesError::InvalidData)?;
 
         let value = data[0].reduce();
         let value = value.0[0];


### PR DESCRIPTION
This requires the removal of the `canon` feature, since `dusk-poseidon` stopped providing it, and the removal of the accompanying error. Since decryption *can* error however - signalled by an `Option` from `dusk-poseidon`, a new error type called `Decryption` is also introduced.

I also took the opportunity to rename the `BadLenght` error to `BadLength`.

Resolves #114