### PR TITLE
Bump version to `0.18.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2022-11-02
+
 ### Added
 
 - Add `Error::Decryption` variant [#114]
@@ -186,7 +188,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#69]: https://github.com/dusk-network/phoenix-core/issues/69
 [#67]: https://github.com/dusk-network/phoenix-core/issues/67
 [#61]: https://github.com/dusk-network/phoenix-core/issues/61
-[Unreleased]: https://github.com/dusk-network/phoenix-core/compare/v0.17.1...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix-core/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/dusk-network/phoenix-core/compare/v0.17.1...v0.18.0
 [0.17.1]: https://github.com/dusk-network/phoenix-core/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/dusk-network/phoenix-core/compare/v0.12.0...v0.17.0
 [0.12.0]: https://github.com/dusk-network/phoenix-core/compare/v0.11.0...v0.12.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.17.1"
+version = "0.18.0"
 authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network"]
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix-core"


### PR DESCRIPTION
### Added

- Add `Error::Decryption` variant #114

### Changed

- Update `dusk-poseidon` from `0.26` to `0.28` #114

### Removed

- Remove `canon` feature #114
- Remove `Error::PoseidonError` variant #114
