### PR TITLE
Release `0.18.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.1] - 2023-01-20
+
 ## Added
 
 - Add `allow_signature_message`, `stake_signature_message`,
@@ -203,7 +205,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#69]: https://github.com/dusk-network/phoenix-core/issues/69
 [#67]: https://github.com/dusk-network/phoenix-core/issues/67
 [#61]: https://github.com/dusk-network/phoenix-core/issues/61
-[Unreleased]: https://github.com/dusk-network/phoenix-core/compare/v0.18.0...HEAD
+
+[Unreleased]: https://github.com/dusk-network/phoenix-core/compare/v0.18.1...HEAD
+[0.18.1]: https://github.com/dusk-network/phoenix-core/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/dusk-network/phoenix-core/compare/v0.17.1...v0.18.0
 [0.17.1]: https://github.com/dusk-network/phoenix-core/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/dusk-network/phoenix-core/compare/v0.12.0...v0.17.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network"]
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix-core"


### PR DESCRIPTION
## [0.18.1] - 2023-01-20

## Added

- Add `allow_signature_message`, `stake_signature_message`,
  `unstake_signature_message`, and `withdraw_signature_message`
  to generate signature messages for stake contract interaction [#119]
- Add `stct_signature_message` and `stco_signature_message` to generate
  signature messages for transfer contract interaction [#119]
- Add `Stake`, `Unstake`, `Withdraw`, `Allow`, and `StakeData` structs to allow
  interaction with the stake contract [#119]
- Add `Stct`, `Wfct`, `Stco`, `Wfco`, `Wfctc`, `Mint`, and `TreeLeaf` structs to
  allow interaction with the transfer contract [#119]
- Add `Transaction` structure [#116]

[0.18.1]: https://github.com/dusk-network/phoenix-core/compare/v0.18.0...v0.18.1
