### PR TITLE
bump version to `0.19.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2023-05-17
+
 ### Changed
 
 - Remove `enc`, `R` and `nonce` from note hash [#123]
@@ -210,7 +212,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#67]: https://github.com/dusk-network/phoenix-core/issues/67
 [#61]: https://github.com/dusk-network/phoenix-core/issues/61
 
-[Unreleased]: https://github.com/dusk-network/phoenix-core/compare/v0.18.1...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix-core/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/dusk-network/phoenix-core/compare/v0.18.1...v0.19.0
 [0.18.1]: https://github.com/dusk-network/phoenix-core/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/dusk-network/phoenix-core/compare/v0.17.1...v0.18.0
 [0.17.1]: https://github.com/dusk-network/phoenix-core/compare/v0.17.0...v0.17.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.18.1"
+version = "0.19.0"
 authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network"]
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix-core"


### PR DESCRIPTION
## [0.19.0] - 2023-05-17

### Changed

- Remove `enc`, `R` and `nonce` from note hash [#123]

[0.19.0]: https://github.com/dusk-network/phoenix-core/compare/v0.18.1...v0.19.0