### PR TITLE
 Add Phoenix protocol's related keys from dusk_pki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[0.21.0] - 2023-10-12
+### Added
+
+- Move `PublicSpendKey` (now named `PublicKey`), `SecretSpendKey` (now named `SecretKey`), `SteathAddress`, `ViewKey` from dusk_pki [#126]
+
+## [0.21.0] - 2023-10-12
 
 ### Changed
 
@@ -213,6 +217,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removal of anyhow error implementation.
 - Canonical implementation shielded by feature.
 
+[#126]: https://github.com/dusk-network/phoenix-core/issues/126
 [#119]: https://github.com/dusk-network/phoenix-core/issues/119
 [#116]: https://github.com/dusk-network/phoenix-core/issues/116
 [#114]: https://github.com/dusk-network/phoenix-core/issues/114

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ dusk-bls12_381 = { version = "0.12", default-features = false }
 dusk-bls12_381-sign = { version = "0.5", default-features = false }
 dusk-jubjub = { version = "0.13", default-features = false }
 dusk-poseidon = { version = "0.31", default-features = false }
-dusk-pki = { version = "0.13", default-features = false }
+dusk-schnorr = { version = "0.15.0", default-features = false }
+subtle = { version = "^2.2.1", default-features = false }
 rkyv = { version = "0.7", optional = true, default-features = false }
 bytecheck = { version = "0.6", optional = true, default-features = false }
 ff = { version = "0.13", default-features = false }
@@ -31,7 +32,7 @@ alloc = []
 rkyv-impl = [
     "dusk-poseidon/rkyv-impl",
     "dusk-jubjub/rkyv-impl",
-    "dusk-pki/rkyv-impl",
+    "dusk-schnorr/rkyv-impl",
     "dusk-bls12_381/rkyv-impl",
     "dusk-bls12_381-sign/rkyv-impl",
     "rkyv",

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -5,11 +5,11 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::note::TRANSPARENT_BLINDER;
-use crate::{BlsScalar, JubJubScalar};
 use crate::{Crossover, Error, Fee, Note, NoteType, Remainder};
 
 use core::convert::TryFrom;
-use dusk_jubjub::{GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED};
+use dusk_bls12_381::BlsScalar;
+use dusk_jubjub::{JubJubScalar, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED};
 use dusk_poseidon::cipher::PoseidonCipher;
 
 impl From<(Fee, Crossover)> for Note {

--- a/src/crossover.rs
+++ b/src/crossover.rs
@@ -6,10 +6,9 @@
 
 //! Fee module contains the logic related to `Crossover` structure
 
-use crate::{BlsScalar, JubJubExtended};
-
+use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
-use dusk_jubjub::JubJubAffine;
+use dusk_jubjub::{JubJubAffine, JubJubExtended};
 use dusk_poseidon::cipher::PoseidonCipher;
 use dusk_poseidon::sponge;
 

--- a/src/fee.rs
+++ b/src/fee.rs
@@ -6,8 +6,10 @@
 
 //! Fee module contains the logic related to `Fee` and `Remainder` structure
 
+use crate::{Ownable, PublicKey, StealthAddress};
+use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
-use dusk_pki::{Ownable, PublicSpendKey, StealthAddress};
+use dusk_jubjub::JubJubScalar;
 use dusk_poseidon::sponge::hash;
 use rand_core::{CryptoRng, RngCore};
 
@@ -15,8 +17,6 @@ use rand_core::{CryptoRng, RngCore};
 use rkyv::{Archive, Deserialize, Serialize};
 
 use core::cmp;
-
-use crate::{BlsScalar, JubJubScalar};
 
 mod remainder;
 pub use remainder::Remainder;
@@ -50,7 +50,7 @@ impl Fee {
         rng: &mut R,
         gas_limit: u64,
         gas_price: u64,
-        psk: &PublicSpendKey,
+        psk: &PublicKey,
     ) -> Self {
         let r = JubJubScalar::random(rng);
 
@@ -62,7 +62,7 @@ impl Fee {
         gas_limit: u64,
         gas_price: u64,
         r: &JubJubScalar,
-        psk: &PublicSpendKey,
+        psk: &PublicKey,
     ) -> Self {
         let stealth_address = psk.gen_stealth_address(r);
 

--- a/src/fee/remainder.rs
+++ b/src/fee/remainder.rs
@@ -6,15 +6,13 @@
 
 //! Remainder module contains the logic related to `Remainder` structure
 
-use dusk_pki::Ownable;
-use dusk_pki::StealthAddress;
+use crate::{Ownable, StealthAddress};
 
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize, Serialize};
 
+use dusk_bls12_381::BlsScalar;
 use dusk_poseidon::sponge::hash;
-
-use crate::BlsScalar;
 
 /// The Remainder structure.
 #[derive(Clone, Copy, Debug)]

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+pub mod public;
+pub mod secret;
+pub mod stealth;
+pub mod view;

--- a/src/keys/public.rs
+++ b/src/keys/public.rs
@@ -1,0 +1,105 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use crate::{permutation, SecretKey, StealthAddress};
+
+use dusk_jubjub::{JubJubAffine, JubJubExtended, JubJubScalar};
+
+#[cfg(feature = "rkyv-impl")]
+use rkyv::{Archive, Deserialize, Serialize};
+
+use dusk_bytes::{DeserializableSlice, Error, HexDebug, Serializable};
+use dusk_jubjub::GENERATOR_EXTENDED;
+use subtle::{Choice, ConstantTimeEq};
+
+/// Public pair of `a·G` and `b·G` defining a [`PublicKey`]
+#[derive(HexDebug, Clone, Copy)]
+#[cfg_attr(
+    feature = "rkyv-impl",
+    derive(Archive, Serialize, Deserialize),
+    archive_attr(derive(bytecheck::CheckBytes))
+)]
+pub struct PublicKey {
+    A: JubJubExtended,
+    B: JubJubExtended,
+}
+
+impl PublicKey {
+    /// This method is used to construct a new `PublicKey` from the given
+    /// public pair of `a·G` and `b·G`
+    pub fn new(A: JubJubExtended, B: JubJubExtended) -> Self {
+        Self { A, B }
+    }
+
+    /// Gets `A` (`a·G`)
+    pub fn A(&self) -> &JubJubExtended {
+        &self.A
+    }
+
+    /// Gets `B` (`b·G`)
+    pub fn B(&self) -> &JubJubExtended {
+        &self.B
+    }
+
+    /// Generates new `PKr = H(A · r) · G + B` from a given `r`
+    pub fn gen_stealth_address(&self, r: &JubJubScalar) -> StealthAddress {
+        let G = GENERATOR_EXTENDED;
+        let R = G * r;
+
+        let rA = self.A * r;
+        let rA = permutation::hash(&rA);
+        let rA = G * rA;
+
+        let pk_r = rA + self.B;
+        let pk_r = pk_r.into();
+
+        StealthAddress { R, pk_r }
+    }
+}
+
+impl ConstantTimeEq for PublicKey {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.A.ct_eq(&other.A) & self.B.ct_eq(&other.B)
+    }
+}
+
+impl PartialEq for PublicKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.ct_eq(other).into()
+    }
+}
+
+impl Eq for PublicKey {}
+
+impl From<SecretKey> for PublicKey {
+    fn from(secret: SecretKey) -> Self {
+        secret.public_key()
+    }
+}
+
+impl From<&SecretKey> for PublicKey {
+    fn from(secret: &SecretKey) -> Self {
+        secret.public_key()
+    }
+}
+
+impl Serializable<64> for PublicKey {
+    type Error = Error;
+
+    fn to_bytes(&self) -> [u8; Self::SIZE] {
+        let mut bytes = [0u8; Self::SIZE];
+        bytes[..32].copy_from_slice(&JubJubAffine::from(self.A).to_bytes());
+        bytes[32..].copy_from_slice(&JubJubAffine::from(self.B).to_bytes());
+        bytes
+    }
+
+    fn from_bytes(bytes: &[u8; Self::SIZE]) -> Result<Self, Self::Error> {
+        let A = JubJubExtended::from(JubJubAffine::from_slice(&bytes[..32])?);
+        let B = JubJubExtended::from(JubJubAffine::from_slice(&bytes[32..])?);
+
+        Ok(Self { A, B })
+    }
+}

--- a/src/keys/secret.rs
+++ b/src/keys/secret.rs
@@ -1,0 +1,110 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use crate::{permutation, PublicKey, StealthAddress, ViewKey};
+use dusk_jubjub::JubJubScalar;
+use dusk_schnorr::NoteSecretKey;
+
+#[cfg(feature = "rkyv-impl")]
+use rkyv::{Archive, Deserialize, Serialize};
+
+use dusk_bytes::{DeserializableSlice, Error, HexDebug, Serializable};
+use dusk_jubjub::GENERATOR_EXTENDED;
+use rand_core::{CryptoRng, RngCore};
+use subtle::{Choice, ConstantTimeEq};
+
+/// Secret pair of `a` and `b` defining a [`SecretKey`]
+#[derive(Clone, Copy, Eq, HexDebug)]
+#[cfg_attr(
+    feature = "rkyv-impl",
+    derive(Archive, Serialize, Deserialize),
+    archive_attr(derive(bytecheck::CheckBytes))
+)]
+pub struct SecretKey {
+    a: JubJubScalar,
+    b: JubJubScalar,
+}
+
+impl SecretKey {
+    /// This method is used to construct a new `SecretKey` from the given
+    /// secret pair of `a` and `b`.
+    pub fn new(a: JubJubScalar, b: JubJubScalar) -> Self {
+        Self { a, b }
+    }
+
+    /// Gets `a`
+    pub fn a(&self) -> &JubJubScalar {
+        &self.a
+    }
+
+    /// Gets `b`
+    pub fn b(&self) -> &JubJubScalar {
+        &self.b
+    }
+
+    /// Deterministically create a new [`SecretKey`] from a random number
+    /// generator
+    pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+        let a = JubJubScalar::random(rng);
+        let b = JubJubScalar::random(rng);
+
+        SecretKey::new(a, b)
+    }
+
+    /// Generates a [`NoteSecretKey`] using the [`StealthAddress`] given.
+    /// With the formula: `sk_r = H(a · R) + b`
+    pub fn sk_r(&self, sa: &StealthAddress) -> NoteSecretKey {
+        let aR = sa.R() * self.a;
+        let aR = permutation::hash(&aR);
+
+        (aR + self.b).into()
+    }
+
+    /// Derive the secret to deterministically construct a [`PublicKey`]
+    pub fn public_key(&self) -> PublicKey {
+        let A = GENERATOR_EXTENDED * self.a;
+        let B = GENERATOR_EXTENDED * self.b;
+
+        PublicKey::new(A, B)
+    }
+
+    /// Derive the secret to deterministically construct a [`ViewKey`]
+    pub fn view_key(&self) -> ViewKey {
+        let B = GENERATOR_EXTENDED * self.b;
+
+        ViewKey::new(self.a, B)
+    }
+}
+
+impl ConstantTimeEq for SecretKey {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.a.ct_eq(&other.a) & self.b.ct_eq(&other.b)
+    }
+}
+
+impl PartialEq for SecretKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.ct_eq(other).into()
+    }
+}
+
+impl Serializable<64> for SecretKey {
+    type Error = Error;
+
+    fn to_bytes(&self) -> [u8; 64] {
+        let mut bytes = [0u8; 64];
+        bytes[..32].copy_from_slice(&self.a.to_bytes());
+        bytes[32..].copy_from_slice(&self.b.to_bytes());
+        bytes
+    }
+
+    fn from_bytes(buf: &[u8; 64]) -> Result<Self, Self::Error> {
+        let a = JubJubScalar::from_slice(&buf[..32])?;
+        let b = JubJubScalar::from_slice(&buf[32..])?;
+
+        Ok(Self { a, b })
+    }
+}

--- a/src/keys/stealth.rs
+++ b/src/keys/stealth.rs
@@ -1,0 +1,111 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_jubjub::{JubJubAffine, JubJubExtended};
+use dusk_schnorr::NotePublicKey;
+
+use dusk_bytes::{DeserializableSlice, Error, HexDebug, Serializable};
+
+use subtle::{Choice, ConstantTimeEq};
+
+#[cfg(feature = "rkyv-impl")]
+use rkyv::{Archive, Deserialize, Serialize};
+
+/// To obfuscate the identity of the participants, we utilizes a Stealth Address
+/// system.
+/// A `StealthAddress` is composed by a one-time public key (`pk_r`, the actual
+// address) and a random point `R`.
+#[derive(Default, HexDebug, Clone, Copy)]
+#[cfg_attr(
+    feature = "rkyv-impl",
+    derive(Archive, Serialize, Deserialize),
+    archive_attr(derive(bytecheck::CheckBytes))
+)]
+pub struct StealthAddress {
+    pub(crate) R: JubJubExtended,
+    pub(crate) pk_r: NotePublicKey,
+}
+
+/// The trait `Ownable` is required by any type that wants to prove its
+/// ownership.
+pub trait Ownable {
+    /// Returns the associated `StealthAddress`
+    fn stealth_address(&self) -> &StealthAddress;
+}
+
+impl StealthAddress {
+    /// Create a stealth address from its internal parts
+    ///
+    /// A stealth address is intended to be generated as the public counterpart
+    /// of a one time secret key. If the user opts to generate the
+    /// stealth address from points, there is no guarantee a secret one time
+    /// key counterpart will be known, and this stealth address will
+    /// not provide the required arguments to generate it.
+    ///
+    /// For additional information, check [PublicKey::from_raw_unchecked].
+    pub const fn from_raw_unchecked(
+        R: JubJubExtended,
+        pk_r: NotePublicKey,
+    ) -> Self {
+        Self { R, pk_r }
+    }
+
+    /// Gets the random point `R`
+    pub const fn R(&self) -> &JubJubExtended {
+        &self.R
+    }
+
+    /// Gets the `pk_r`
+    pub const fn pk_r(&self) -> &NotePublicKey {
+        &self.pk_r
+    }
+
+    /// Gets the underline `JubJubExtended` point of `pk_r`
+    pub fn address(&self) -> &JubJubExtended {
+        self.pk_r.as_ref()
+    }
+}
+
+impl ConstantTimeEq for StealthAddress {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.pk_r.as_ref().ct_eq(other.pk_r.as_ref()) & self.R.ct_eq(&other.R)
+    }
+}
+
+impl PartialEq for StealthAddress {
+    fn eq(&self, other: &Self) -> bool {
+        self.ct_eq(other).into()
+    }
+}
+
+impl Ownable for StealthAddress {
+    fn stealth_address(&self) -> &StealthAddress {
+        self
+    }
+}
+
+impl Serializable<64> for StealthAddress {
+    type Error = Error;
+    /// Encode the `StealthAddress` to an array of 64 bytes
+    fn to_bytes(&self) -> [u8; Self::SIZE] {
+        let mut bytes = [0u8; Self::SIZE];
+        bytes[..32].copy_from_slice(&JubJubAffine::from(self.R).to_bytes());
+        bytes[32..].copy_from_slice(
+            &JubJubAffine::from(self.pk_r.as_ref()).to_bytes(),
+        );
+        bytes
+    }
+
+    /// Decode the `StealthAddress` from an array of 64 bytes
+    fn from_bytes(bytes: &[u8; Self::SIZE]) -> Result<Self, Error> {
+        let R = JubJubExtended::from(JubJubAffine::from_slice(&bytes[..32])?);
+        let pk_r =
+            JubJubExtended::from(JubJubAffine::from_slice(&bytes[32..])?);
+        let pk_r = NotePublicKey::from_raw_unchecked(pk_r);
+
+        Ok(StealthAddress { R, pk_r })
+    }
+}

--- a/src/keys/view.rs
+++ b/src/keys/view.rs
@@ -1,0 +1,115 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use crate::keys::stealth;
+
+use crate::{permutation, PublicKey, SecretKey};
+
+use dusk_bytes::{DeserializableSlice, Error, HexDebug, Serializable};
+use dusk_jubjub::{
+    JubJubAffine, JubJubExtended, JubJubScalar, GENERATOR_EXTENDED,
+};
+use subtle::{Choice, ConstantTimeEq};
+
+#[cfg(feature = "rkyv-impl")]
+use rkyv::{Archive, Deserialize, Serialize};
+
+/// Pair of a secret `a` and public `b·G`
+///
+/// The notes are encrypted against secret a, so this is used to decrypt the
+/// blinding factor and value
+#[derive(Clone, Copy, HexDebug)]
+#[cfg_attr(
+    feature = "rkyv-impl",
+    derive(Archive, Serialize, Deserialize),
+    archive_attr(derive(bytecheck::CheckBytes))
+)]
+pub struct ViewKey {
+    a: JubJubScalar,
+    B: JubJubExtended,
+}
+
+impl ConstantTimeEq for ViewKey {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        // TODO - Why self.a is not checked?
+        self.B.ct_eq(&other.B)
+    }
+}
+
+impl PartialEq for ViewKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.a == other.a && self.ct_eq(other).into()
+    }
+}
+
+impl Eq for ViewKey {}
+
+impl ViewKey {
+    /// This method is used to construct a new `ViewKey` from the given
+    /// pair of secret `a` and public `b·G`.
+    pub fn new(a: JubJubScalar, B: JubJubExtended) -> Self {
+        Self { a, B }
+    }
+
+    /// Derive the secret to deterministically construct a [`PublicKey`]
+    pub fn public_key(&self) -> PublicKey {
+        let A = GENERATOR_EXTENDED * self.a;
+
+        PublicKey::new(A, self.B)
+    }
+
+    /// Gets `a`
+    pub fn a(&self) -> &JubJubScalar {
+        &self.a
+    }
+
+    /// Gets `B` (`b·G`)
+    pub fn B(&self) -> &JubJubExtended {
+        &self.B
+    }
+
+    /// Checks `PKr = H(R · a) · G + B`
+    pub fn owns(&self, owner: &impl stealth::Ownable) -> bool {
+        let sa = owner.stealth_address();
+
+        let aR = sa.R() * self.a();
+        let aR = permutation::hash(&aR);
+        let aR = GENERATOR_EXTENDED * aR;
+        let pk_r = aR + self.B();
+
+        sa.address() == &pk_r
+    }
+}
+
+impl From<SecretKey> for ViewKey {
+    fn from(secret: SecretKey) -> Self {
+        secret.view_key()
+    }
+}
+
+impl From<&SecretKey> for ViewKey {
+    fn from(secret: &SecretKey) -> Self {
+        secret.view_key()
+    }
+}
+
+impl Serializable<64> for ViewKey {
+    type Error = Error;
+
+    fn to_bytes(&self) -> [u8; 64] {
+        let mut bytes = [0u8; 64];
+        bytes[..32].copy_from_slice(&self.a.to_bytes());
+        bytes[32..].copy_from_slice(&JubJubAffine::from(&self.B).to_bytes());
+        bytes
+    }
+
+    fn from_bytes(buf: &[u8; 64]) -> Result<Self, Self::Error> {
+        let a = JubJubScalar::from_slice(&buf[..32])?;
+        let B = JubJubExtended::from(JubJubAffine::from_slice(&buf[32..])?);
+
+        Ok(Self { a, B })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,20 @@ pub mod message;
 /// Transparent and Obfuscated Notes
 pub mod note;
 
+/// Phoenix Core Keys & Addresses
+mod keys;
+
+mod permutation;
+
+/// Public (Spend) Key
+pub use keys::public::PublicKey;
+/// Secret (Spend) Key
+pub use keys::secret::SecretKey;
+/// Stealth Address
+pub use keys::stealth::{Ownable, StealthAddress};
+/// ViewKey
+pub use keys::view::ViewKey;
+
 /// Transaction types & utilities
 #[cfg(feature = "alloc")]
 pub mod transaction;
@@ -38,6 +52,3 @@ pub use message::Message;
 pub use note::{Note, NoteType};
 #[cfg(feature = "alloc")]
 pub use transaction::Transaction;
-
-use dusk_bls12_381::BlsScalar;
-use dusk_jubjub::{JubJubAffine, JubJubExtended, JubJubScalar};

--- a/src/message.rs
+++ b/src/message.rs
@@ -4,14 +4,15 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::{BlsScalar, Error, JubJubExtended, JubJubScalar, Note, NoteType};
+use crate::{Error, Note, NoteType};
 
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize, Serialize};
 
+use crate::PublicKey;
+use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Serializable};
-use dusk_jubjub::{dhke, JubJubAffine};
-use dusk_pki::PublicSpendKey;
+use dusk_jubjub::{dhke, JubJubAffine, JubJubExtended, JubJubScalar};
 use dusk_poseidon::cipher::PoseidonCipher;
 use dusk_poseidon::sponge;
 use ff::Field;
@@ -37,7 +38,7 @@ impl Message {
     pub fn new<R: RngCore + CryptoRng>(
         rng: &mut R,
         r: &JubJubScalar,
-        psk: &PublicSpendKey,
+        psk: &PublicKey,
         value: u64,
     ) -> Self {
         let nonce = BlsScalar::random(&mut *rng);
@@ -111,7 +112,7 @@ impl Message {
     pub fn decrypt(
         &self,
         r: &JubJubScalar,
-        psk: &PublicSpendKey,
+        psk: &PublicKey,
     ) -> Result<(u64, JubJubScalar), Error> {
         let shared_secret = dhke(r, psk.A());
         let nonce = self.nonce;

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_jubjub::{JubJubExtended, JubJubScalar};
+use dusk_poseidon::sponge::truncated;
+
+/// Hashes a JubJub's ExtendedPoint into a JubJub's Scalar using the poseidon
+/// hash function
+pub fn hash(p: &JubJubExtended) -> JubJubScalar {
+    truncated::hash(&p.to_hash_inputs())
+}

--- a/src/transaction/stake.rs
+++ b/src/transaction/stake.rs
@@ -6,10 +6,10 @@
 
 use alloc::vec::Vec;
 
+use crate::StealthAddress;
 use dusk_bls12_381::BlsScalar;
 use dusk_bls12_381_sign::{PublicKey, Signature};
 use dusk_bytes::Serializable;
-use dusk_pki::StealthAddress;
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize, Serialize};
 

--- a/src/transaction/transfer.rs
+++ b/src/transaction/transfer.rs
@@ -7,16 +7,15 @@
 use alloc::vec::Vec;
 
 use dusk_bls12_381::BlsScalar;
-use dusk_pki::StealthAddress;
 use dusk_poseidon::cipher::PoseidonCipher;
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize, Serialize};
 
-use super::ModuleId;
-
 use crate::crossover::Crossover;
 use crate::message::Message;
 use crate::note::Note;
+use crate::transaction::ModuleId;
+use crate::StealthAddress;
 
 /// The depth of the transfer tree.
 pub const TRANSFER_TREE_DEPTH: usize = 17;

--- a/tests/crossover.rs
+++ b/tests/crossover.rs
@@ -7,16 +7,15 @@
 use core::convert::TryInto;
 
 use dusk_jubjub::JubJubScalar;
-use dusk_pki::SecretSpendKey;
-use phoenix_core::{Error, Message, Note};
+use phoenix_core::{Error, Message, Note, SecretKey};
 use rand_core::OsRng;
 
 #[test]
 fn crossover_hash() -> Result<(), Error> {
     let rng = &mut OsRng;
 
-    let ssk = SecretSpendKey::random(rng);
-    let psk = ssk.public_spend_key();
+    let ssk = SecretKey::random(rng);
+    let psk = ssk.public_key();
 
     let value = 25;
     let blinding_factor = JubJubScalar::random(rng);
@@ -41,8 +40,8 @@ fn crossover_hash() -> Result<(), Error> {
 fn message_hash() -> Result<(), Error> {
     let rng = &mut OsRng;
 
-    let ssk = SecretSpendKey::random(rng);
-    let psk = ssk.public_spend_key();
+    let ssk = SecretKey::random(rng);
+    let psk = ssk.public_key();
     let value = 25;
 
     let r = JubJubScalar::random(rng);

--- a/tests/keys.rs
+++ b/tests/keys.rs
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_bytes::{DeserializableSlice, ParseHexStr, Serializable};
+use phoenix_core::{PublicKey, SecretKey, ViewKey};
+use rand_core::OsRng;
+
+#[test]
+fn ssk_from_bytes() {
+    let ssk_a = SecretKey::random(&mut OsRng);
+    let bytes = ssk_a.to_bytes();
+    let ssk_b = SecretKey::from_slice(&bytes).expect("Serde error");
+
+    assert_eq!(ssk_a, ssk_b);
+}
+
+#[test]
+fn keys_encoding() {
+    let ssk = SecretKey::random(&mut OsRng);
+    let vk = ssk.view_key();
+    let psk = ssk.public_key();
+
+    assert_eq!(
+        vk,
+        ViewKey::from_hex_str(format!("{:x}", vk).as_str()).unwrap()
+    );
+    assert_eq!(
+        psk,
+        PublicKey::from_hex_str(format!("{:x}", psk).as_str()).unwrap()
+    );
+}
+
+#[test]
+fn keys_consistency() {
+    use dusk_jubjub::{JubJubScalar, GENERATOR_EXTENDED};
+
+    let r = JubJubScalar::random(&mut OsRng);
+    let ssk = SecretKey::random(&mut OsRng);
+    let psk = ssk.public_key();
+    let vk = ssk.view_key();
+    let sa = psk.gen_stealth_address(&r);
+
+    assert!(vk.owns(&sa));
+
+    let wrong_ssk = SecretKey::random(&mut OsRng);
+    let wrong_vk = wrong_ssk.view_key();
+
+    assert_ne!(ssk, wrong_ssk);
+    assert_ne!(vk, wrong_vk);
+
+    assert!(!wrong_vk.owns(&sa));
+
+    let sk_r = ssk.sk_r(&sa);
+    let wrong_sk_r = wrong_ssk.sk_r(&sa);
+
+    assert_eq!(sa.address(), &(GENERATOR_EXTENDED * sk_r.as_ref()));
+    assert_ne!(sa.address(), &(GENERATOR_EXTENDED * wrong_sk_r.as_ref()));
+}

--- a/tests/message.rs
+++ b/tests/message.rs
@@ -7,17 +7,16 @@
 use dusk_bytes::Serializable;
 use dusk_jubjub::JubJubScalar;
 use dusk_jubjub::{GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED};
-use dusk_pki::SecretSpendKey;
-use phoenix_core::Message;
+use phoenix_core::{Message, SecretKey};
 use rand_core::OsRng;
 
 #[test]
 fn message_consistency() {
     let rng = &mut OsRng;
 
-    let ssk = SecretSpendKey::random(rng);
-    let psk = ssk.public_spend_key();
-    let psk_wrong = SecretSpendKey::random(rng).public_spend_key();
+    let ssk = SecretKey::random(rng);
+    let psk = ssk.public_key();
+    let psk_wrong = SecretKey::random(rng).public_key();
 
     let r = JubJubScalar::random(rng);
     let r_wrong = JubJubScalar::random(rng);
@@ -41,8 +40,8 @@ fn message_consistency() {
 fn message_bytes() {
     let rng = &mut OsRng;
 
-    let ssk = SecretSpendKey::random(rng);
-    let psk = ssk.public_spend_key();
+    let ssk = SecretKey::random(rng);
+    let psk = ssk.public_key();
 
     let r = JubJubScalar::random(rng);
     let value = 106;

--- a/tests/note_test.rs
+++ b/tests/note_test.rs
@@ -7,17 +7,16 @@
 use core::convert::TryInto;
 use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{JubJubScalar, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED};
-use dusk_pki::{Ownable, SecretSpendKey};
 use ff::Field;
-use phoenix_core::{Crossover, Error, Fee, Note, NoteType};
+use phoenix_core::{Crossover, Error, Fee, Note, NoteType, Ownable, SecretKey};
 use rand_core::OsRng;
 
 #[test]
 fn transparent_note() -> Result<(), Error> {
     let rng = &mut OsRng;
 
-    let ssk = SecretSpendKey::random(rng);
-    let psk = ssk.public_spend_key();
+    let ssk = SecretKey::random(rng);
+    let psk = ssk.public_key();
     let value = 25;
 
     let note = Note::transparent(rng, &psk, value);
@@ -32,8 +31,8 @@ fn transparent_note() -> Result<(), Error> {
 fn transparent_stealth_note() -> Result<(), Error> {
     let mut rng = OsRng;
 
-    let ssk = SecretSpendKey::random(&mut rng);
-    let psk = ssk.public_spend_key();
+    let ssk = SecretKey::random(&mut rng);
+    let psk = ssk.public_key();
 
     let r = JubJubScalar::random(&mut rng);
 
@@ -54,8 +53,8 @@ fn transparent_stealth_note() -> Result<(), Error> {
 fn obfuscated_note() -> Result<(), Error> {
     let rng = &mut OsRng;
 
-    let ssk = SecretSpendKey::random(rng);
-    let psk = ssk.public_spend_key();
+    let ssk = SecretKey::random(rng);
+    let psk = ssk.public_key();
     let vk = ssk.view_key();
     let value = 25;
 
@@ -72,8 +71,8 @@ fn obfuscated_note() -> Result<(), Error> {
 fn obfuscated_deterministic_note() -> Result<(), Error> {
     let mut rng = OsRng;
 
-    let ssk = SecretSpendKey::random(&mut rng);
-    let psk = ssk.public_spend_key();
+    let ssk = SecretKey::random(&mut rng);
+    let psk = ssk.public_key();
     let vk = ssk.view_key();
     let value = 25;
 
@@ -100,9 +99,9 @@ fn obfuscated_deterministic_note() -> Result<(), Error> {
 fn value_commitment_transparent() {
     let rng = &mut OsRng;
 
-    let ssk = SecretSpendKey::random(rng);
+    let ssk = SecretKey::random(rng);
     let vsk = ssk.view_key();
-    let psk = ssk.public_spend_key();
+    let psk = ssk.public_key();
     let value = 25;
 
     let note = Note::transparent(rng, &psk, value);
@@ -127,9 +126,9 @@ fn value_commitment_transparent() {
 fn value_commitment_obfuscated() {
     let rng = &mut OsRng;
 
-    let ssk = SecretSpendKey::random(rng);
+    let ssk = SecretKey::random(rng);
     let vsk = ssk.view_key();
-    let psk = ssk.public_spend_key();
+    let psk = ssk.public_key();
     let value = 25;
 
     let blinding_factor = JubJubScalar::random(rng);
@@ -155,12 +154,12 @@ fn value_commitment_obfuscated() {
 fn note_keys_consistency() {
     let rng = &mut OsRng;
 
-    let ssk = SecretSpendKey::random(rng);
-    let psk = ssk.public_spend_key();
+    let ssk = SecretKey::random(rng);
+    let psk = ssk.public_key();
     let vk = ssk.view_key();
     let value = 25;
 
-    let wrong_ssk = SecretSpendKey::random(rng);
+    let wrong_ssk = SecretKey::random(rng);
     let wrong_vk = wrong_ssk.view_key();
 
     assert_ne!(ssk, wrong_ssk);
@@ -177,8 +176,8 @@ fn note_keys_consistency() {
 fn fee_and_crossover_generation() -> Result<(), Error> {
     let rng = &mut OsRng;
 
-    let ssk = SecretSpendKey::random(rng);
-    let psk = ssk.public_spend_key();
+    let ssk = SecretKey::random(rng);
+    let psk = ssk.public_key();
     let vk = ssk.view_key();
     let value = 25;
 
@@ -186,7 +185,7 @@ fn fee_and_crossover_generation() -> Result<(), Error> {
     let note = Note::obfuscated(rng, &psk, value, blinding_factor);
     let (fee, crossover): (Fee, Crossover) = note.try_into()?;
 
-    let ssk_fee = SecretSpendKey::random(rng);
+    let ssk_fee = SecretKey::random(rng);
     let wrong_fee = Fee::new(rng, 0, 0, &ssk_fee.into());
     let wrong_note: Note = (wrong_fee, crossover).into();
 
@@ -207,8 +206,8 @@ fn fee_and_crossover_generation() -> Result<(), Error> {
 fn fail_fee_and_crossover_from_transparent() {
     let rng = &mut OsRng;
 
-    let ssk = SecretSpendKey::random(rng);
-    let psk = ssk.public_spend_key();
+    let ssk = SecretKey::random(rng);
+    let psk = ssk.public_key();
     let value = 25;
 
     let note = Note::transparent(rng, &psk, value);
@@ -224,8 +223,8 @@ fn fail_fee_and_crossover_from_transparent() {
 fn transparent_from_fee_remainder() -> Result<(), Error> {
     let rng = &mut OsRng;
 
-    let ssk = SecretSpendKey::random(rng);
-    let psk = ssk.public_spend_key();
+    let ssk = SecretKey::random(rng);
+    let psk = ssk.public_key();
     let vk = ssk.view_key();
 
     let gas_consumed = 3;
@@ -249,8 +248,8 @@ fn transparent_from_fee_remainder() -> Result<(), Error> {
 fn transparent_from_fee_remainder_with_invalid_consumed() -> Result<(), Error> {
     let rng = &mut OsRng;
 
-    let ssk = SecretSpendKey::random(rng);
-    let psk = ssk.public_spend_key();
+    let ssk = SecretKey::random(rng);
+    let psk = ssk.public_key();
     let vk = ssk.view_key();
 
     let gas_consumed = 30;

--- a/tests/transaction.rs
+++ b/tests/transaction.rs
@@ -10,16 +10,15 @@ use core::convert::TryInto;
 
 use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::JubJubScalar;
-use dusk_pki::SecretSpendKey;
-use phoenix_core::{Error, Note, Transaction};
+use phoenix_core::{Error, Note, SecretKey, Transaction};
 use rand_core::OsRng;
 
 #[test]
 fn transaction_parse() -> Result<(), Error> {
     let rng = &mut OsRng;
 
-    let ssk = SecretSpendKey::random(rng);
-    let psk = ssk.public_spend_key();
+    let ssk = SecretKey::random(rng);
+    let psk = ssk.public_key();
 
     let value = 25;
     let blinding_factor = JubJubScalar::random(rng);


### PR DESCRIPTION
`PublicSpendKey` is now `PublicKey`
`SecretSpendKey` is now `SecretKey`

The next step is to refactor the code, to align with the desired internal representation of `PublicKey` & `SecretKey` (will be separate PR).