### PR TITLE
Bump to v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0] - 2024-01-03
+
 ## Changed
 
-- Update dusk-poseidon -> 0.32
-- Update dusk-schnorr -> 0.17
+- Update dusk-poseidon -> 0.33
+- Update dusk-schnorr -> 0.18
 
 ## [0.23.0] - 2023-12-13
 
@@ -266,7 +268,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#61]: https://github.com/dusk-network/phoenix-core/issues/61
 
 <!-- ISSUES -->
-[Unreleased]: https://github.com/dusk-network/phoenix-core/compare/v0.23.0...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix-core/compare/v0.24.0...HEAD
+[0.24.0]: https://github.com/dusk-network/phoenix-core/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/dusk-network/phoenix-core/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/dusk-network/phoenix-core/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/dusk-network/phoenix-core/compare/v0.19.0...v0.21.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network"]
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix-core"


### PR DESCRIPTION
## [0.24.0] - 2024-01-03

## Changed

- Update dusk-poseidon -> 0.33
- Update dusk-schnorr -> 0.18


[0.24.0]: https://github.com/dusk-network/phoenix-core/compare/v0.23.0...v0.24.0
