### PR TITLE
Bump to v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2024-01-24
+
 ### Changed
 
 - Exchanged `dusk-schnorr@0.18` dependency for `jubjub-schnorr@0.1`
@@ -273,7 +275,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#61]: https://github.com/dusk-network/phoenix-core/issues/61
 
 <!-- ISSUES -->
-[Unreleased]: https://github.com/dusk-network/phoenix-core/compare/v0.24.0...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix-core/compare/v0.25.0...HEAD
+[0.25.0]: https://github.com/dusk-network/phoenix-core/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/dusk-network/phoenix-core/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/dusk-network/phoenix-core/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/dusk-network/phoenix-core/compare/v0.21.0...v0.22.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.25.0-rc.0"
+version = "0.25.0"
 authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network"]
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix-core"


### PR DESCRIPTION
## [0.25.0] - 2024-01-24

### Changed

- Exchanged `dusk-schnorr@0.18` dependency for `jubjub-schnorr@0.1`
- Exchanged `dusk-bls12_381-sign@0.6` dependency for `bls12_381-bls@0.1`


[0.25.0]: https://github.com/dusk-network/phoenix-core/compare/v0.24.0...v0.25.0
