### PR TITLE
Bump to v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2024-04-10
+
 ### Changed
 
 - Update bls12_381-bls -> 0.2
@@ -281,7 +283,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#61]: https://github.com/dusk-network/phoenix-core/issues/61
 
 <!-- ISSUES -->
-[Unreleased]: https://github.com/dusk-network/phoenix-core/compare/v0.25.0...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix-core/compare/v0.26.0...HEAD
+[0.26.0]: https://github.com/dusk-network/phoenix-core/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/dusk-network/phoenix-core/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/dusk-network/phoenix-core/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/dusk-network/phoenix-core/compare/v0.22.0...v0.23.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "phoenix-core"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network"]
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix-core"
 description = "Anonymity-preserving zero-knowledge proof-powered transaction model"
 license = "MPL-2.0"
-exclude = [".github/workflows/ci.yml", ".gitignore"]
+exclude = [".github/workflows/dusk-ci.yml", ".gitignore"]
 
 [dependencies]
 rand_core = { version = "0.6", default-features = false }


### PR DESCRIPTION
## [0.26.0] - 2024-04-10

### Changed

- Update bls12_381-bls -> 0.2
- Update jubjub-schnorr -> 0.2
- Use Blake for computing the stealth addresses, instead of Poseidon.


[0.26.0]: https://github.com/dusk-network/phoenix-core/compare/v0.25.0...v0.26.0
