### PR TITLE
Bump to v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0] - 2024-04-24
+
 ### Added
 
 - Add an `Encryption` module that uses AES-GCM [#152]
@@ -306,7 +308,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#61]: https://github.com/dusk-network/phoenix-core/issues/61
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/phoenix-core/compare/v0.26.0...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix-core/compare/v0.27.0...HEAD
+[0.27.0]: https://github.com/dusk-network/phoenix-core/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/dusk-network/phoenix-core/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/dusk-network/phoenix-core/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/dusk-network/phoenix-core/compare/v0.23.0...v0.24.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network"]
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix-core"


### PR DESCRIPTION
## [0.27.0] - 2024-04-24

### Added

- Add an `Encryption` module that uses AES-GCM [#152]
- Add `Zeroize` trait implmentation for `SecretKey` [#155]

### Changed

- Use AES-GCM from the `Encryption` module throughout the code, instead of `PoseidonCipher`.
- Rename `SecretKey::sk_r` to `SecretKey::gen_note_sk` [#156]
- Rename `StealthAddress::pk_r` to `StealthAddress::note_pk` [#156]
- Update `bls12_381-bls` to v0.3.0
- Update `jubjub-schnorr` to v0.3.0

### Removed 

- Remove the `Message` module.
- Remove `StealthAddress::address` method [#156]
- Remove `Copy` from `SecretKey` [#155]
- Remove `From<SecretKey>` for `ViewKey` and `PublicKey`, use `From<&SecretKey>` instead [#155]



[0.27.0]: https://github.com/dusk-network/phoenix-core/compare/v0.26.0...v0.27.0
