### PR TITLE
Bump core to v0.28.0 and release circuits at v0.1.0

### DIFF
--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2024-05-22
+
 ### Added
 
 - Add `phoenix-circuits` as a workspace member of `phoenix` [#171]
@@ -27,4 +29,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#169]: https://github.com/dusk-network/phoenix/issues/169
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.27.0...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix/compare/circuits_v0.1.0...HEAD
+[0.1.0]: https://github.com/dusk-network/phoenix/releases/tag/circuits_v0.1.0

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -3,7 +3,7 @@ name = "phoenix-circuits"
 version = "0.1.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/circuits"
-description = "Circuit definitions for Phoenix, an privacy-preserving ZKP-based transaction model"
+description = "Circuit definitions for Phoenix, a privacy-preserving ZKP-based transaction model"
 license = "MPL-2.0"
 exclude = [".github/workflows/dusk-ci.yml", ".gitignore"]
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] - 2024-05-22
+
 ### Added
 
 - Add `empty` method for the `Note` [#165]
@@ -339,7 +341,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#61]: https://github.com/dusk-network/phoenix/issues/61
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.27.0...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.28.0...HEAD
+[0.28.0]: https://github.com/dusk-network/phoenix/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/dusk-network/phoenix/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/dusk-network/phoenix/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/dusk-network/phoenix/compare/v0.24.0...v0.25.0

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "phoenix-core"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/core"
-description = "Core types and functionalities for Phoenix, an privacy-preserving ZKP-based transaction model"
+description = "Core types and functionalities for Phoenix, a privacy-preserving ZKP-based transaction model"
 license = "MPL-2.0"
 exclude = [".github/workflows/dusk-ci.yml", ".gitignore"]
 


### PR DESCRIPTION
## core [0.28.0] - 2024-05-22

### Added

- Add `empty` method for the `Note` [#165]
- Add `From<DuskBytesError>` trait implementation for `Error` [#166]
- Add `ElGamal` encryption module [#162]
- Add impl `Ownable` for `&Note`.

### Changed

- Restructure `Encryption` module.
- Move phoenix-core into a phoenix workspace [#171]
- Rename `note` method to `note_type`.
- Update `dusk-poseidon` to v0.39 [#179]
- Update `jubjub-schnorr` to v0.4 [#179]

### Removed

- Remove 'encryption::elgamal' module as it has been added to the 'phoenix-circuits' lib in the same workspace [#171]
- Remove `Crossover` struct [#175]
- Remove `fee`module [#175]
- Remove `transaction/transfer` module [#175]
- Remove `transaction/stake` module [#175]
- Remove `convert` module [#175]
- Remove error types related to the above modules and types [#175]

---

## circuits [0.1.0] - 2024-05-22

### Added

- Add `phoenix-circuits` as a workspace member of `phoenix` [#171]
- Add elgamal encryption and decryption gadgets [#171]
- Add the `transaction` module [#169]

### Changed

- Change the gadget input to match the order of the circuits public inputs [#177]
- Update `dusk-poseidon` to v0.39 [#179]
- Update `jubjub-schnorr` to v0.4 [#179]
- Update `poseidon-merkle` to v0.6 [#179]


[0.1.0]: https://github.com/dusk-network/phoenix/releases/tag/circuits_v0.1.0
[0.28.0]: https://github.com/dusk-network/phoenix/compare/v0.27.0...v0.28.0
