### PR TITLE
core: Bump to v0.28.1

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.1] - 2024-05-23
+
 ### Changed
 
 - Fix missing import for `rkyv-impl` feature [#183]
@@ -346,7 +348,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#61]: https://github.com/dusk-network/phoenix/issues/61
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.28.0...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.28.1...HEAD
+[0.28.1]: https://github.com/dusk-network/phoenix/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/dusk-network/phoenix/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/dusk-network/phoenix/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/dusk-network/phoenix/compare/v0.25.0...v0.26.0

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/core"
 description = "Core types and functionalities for Phoenix, a privacy-preserving ZKP-based transaction model"


### PR DESCRIPTION
## [0.28.1] - 2024-05-23

### Changed

- Fix missing import for `rkyv-impl` feature [#183]



[0.28.1]: https://github.com/dusk-network/phoenix/compare/v0.28.0...v0.28.1
