### PR TITLE
Add `RecipientParameters` to `TxSkeleton`

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Implement `rkyv` traits for `RecipientParameters`
+- Implement `dusk_bytes::Serializable` for `RecipientParameters`
 - Add `RecipientParameters`
 - Add `elgamal::encrypt` and `elgamal::decrypt`
 - Add `stealth_address` and `sync_address` functions directly to note [#208]
@@ -18,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Include `recipient_params` field in `TxSkeleton`
 - Move `OUTPUT_NOTES` to crate root
 - Change `owns` and `owns_unchecked` to take `&Note` [#208]
 - Change `gen_note_sk` to take `&StealthAddress` [#208]

--- a/core/src/transaction.rs
+++ b/core/src/transaction.rs
@@ -16,10 +16,10 @@ use rkyv::{Archive, Deserialize, Serialize};
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
 
-use crate::{Note, OUTPUT_NOTES};
+use crate::{Note, RecipientParameters, OUTPUT_NOTES};
 
 /// A phoenix transaction, referred to as tx-skeleton in the specs.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Serialize, Deserialize),
@@ -37,6 +37,8 @@ pub struct TxSkeleton {
     pub tx_max_fee: u64,
     /// A deposit is used to transferring funds to a contract
     pub deposit: u64,
+    /// Parameters needed to prove a recipient in-circuit
+    pub recipient_params: RecipientParameters,
 }
 
 impl TxSkeleton {
@@ -56,6 +58,7 @@ impl TxSkeleton {
 
         bytes.extend(self.tx_max_fee.to_bytes());
         bytes.extend(self.deposit.to_bytes());
+        bytes.extend(self.recipient_params.to_bytes());
 
         bytes
     }
@@ -80,6 +83,7 @@ impl TxSkeleton {
 
         bytes.extend(self.tx_max_fee.to_bytes());
         bytes.extend(self.deposit.to_bytes());
+        bytes.extend(self.recipient_params.to_bytes());
 
         bytes
     }
@@ -104,6 +108,7 @@ impl TxSkeleton {
 
         let tx_max_fee = u64::from_reader(&mut buffer)?;
         let deposit = u64::from_reader(&mut buffer)?;
+        let recipient_params = RecipientParameters::from_reader(&mut buffer)?;
 
         Ok(Self {
             root,
@@ -111,6 +116,7 @@ impl TxSkeleton {
             outputs,
             tx_max_fee,
             deposit,
+            recipient_params,
         })
     }
 

--- a/core/tests/transaction.rs
+++ b/core/tests/transaction.rs
@@ -7,9 +7,11 @@
 #![cfg(feature = "alloc")]
 
 use dusk_bls12_381::BlsScalar;
-use dusk_jubjub::JubJubScalar;
+use dusk_jubjub::{JubJubScalar, GENERATOR};
 use ff::Field;
-use phoenix_core::{Error, Note, PublicKey, SecretKey, TxSkeleton};
+use phoenix_core::{
+    Error, Note, PublicKey, RecipientParameters, SecretKey, TxSkeleton,
+};
 use rand::rngs::OsRng;
 
 #[test]
@@ -29,12 +31,22 @@ fn transaction_parse() -> Result<(), Error> {
     let tx_max_fee = 0;
     let deposit = 0;
 
+    let output_npks = [
+        (GENERATOR * JubJubScalar::random(&mut rng)).into(),
+        (GENERATOR * JubJubScalar::random(&mut rng)).into(),
+    ];
+    let hash = BlsScalar::random(&mut rng);
+
+    let recipient_params =
+        RecipientParameters::new(&mut rng, &sk, output_npks, hash);
+
     let tx_skeleton = TxSkeleton {
         root,
         nullifiers,
         outputs,
         tx_max_fee,
         deposit,
+        recipient_params,
     };
     let bytes_of_transaction = tx_skeleton.to_var_bytes();
     assert_eq!(


### PR DESCRIPTION
The `RecipientParameter` are needed in the `TxSkeleton` to create the public-inputs for the verifier.