### PR TITLE
Release core `v0.29.0` and circuits `v0.2.0`

### DIFF
--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2024-06-19
+
 ### Added
 
 - Add Recipient gadget [#197]
@@ -61,4 +63,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- VERSIONS -->
 [Unreleased]: https://github.com/dusk-network/phoenix/compare/circuits_v0.1.0...HEAD
+[0.2.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.1.0...circuits_v0.2.0
 [0.1.0]: https://github.com/dusk-network/phoenix/releases/tag/circuits_v0.1.0

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-circuits"
-version = "0.2.0-rc.3"
+version = "0.2.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/circuits"
 description = "Circuit definitions for Phoenix, a privacy-preserving ZKP-based transaction model"

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0] - 2024-06-19
+
 ### Added
 
 - Add `encrypt_sender` function to encrypt the sender with the npk [#214]
@@ -387,7 +389,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#61]: https://github.com/dusk-network/phoenix/issues/61
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.28.1...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.29.0...HEAD
+[0.29.0]: https://github.com/dusk-network/phoenix/compare/v0.28.1...v0.29.0
 [0.28.1]: https://github.com/dusk-network/phoenix/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/dusk-network/phoenix/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/dusk-network/phoenix/compare/v0.26.0...v0.27.0

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.29.0-rc.3"
+version = "0.29.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/core"
 description = "Core types and functionalities for Phoenix, a privacy-preserving ZKP-based transaction model"


### PR DESCRIPTION
# core

## [0.29.0] - 2024-06-19

### Added

- Add `encrypt_sender` function to encrypt the sender with the npk [#214]
- Add `decrypt_sender` method to the `Note` [#214]
- Add `elgamal::encrypt` and `elgamal::decrypt`
- Add `stealth_address` function directly to note [#208]
- Add function `value_commitment` [#201]
- Add function `transparent_value_commitment` [#201]
- Add `owns()` and `owns_unchecked()` to `Secretkey` [#146]

### Changed

- Rename `tx_max_fee` to `max_fee` [#214]
- Add `sender_enc` field to the `Note` [#214]
- Add `sender_blinder` parameter for `Note` contructors [#214]
- Add `sender_pk` parameter for `Note` contructors [#214]
- Add `sender_enc` parameter for `Note::transparent_stealth` [#214]
- Rename `encryption_blinder` to `value_blinder` [#214]
- Rename `NOTE_ENCRYPTION_SIZE` to `NOTE_VALUE_ENC_SIZE` [#214]
- Move `OUTPUT_NOTES` to crate root
- Change `owns` and `owns_unchecked` to take `&Note` [#208]
- Change `gen_note_sk` to take `&StealthAddress` [#208]
- Rename `crossover` to `deposit` [#190]
- Turn the value-commitment an `JubJubAffine` point [#201]
- Expose `NOTE_ENCRYPTION_SIZE` [#201]
- Make `alloc` a `default` feature [#201]

### Removed

- Remove `Ownable` trait [#208]
- Remove `"getrandom"` feature from `aes-gcm` dependency [#195]


# circuits

## [0.2.0] - 2024-06-19

### Added

- Add Recipient gadget [#197]

### Changed

- Rename `recipient` module to `sender_enc` [#214]
- Rename `blinding_factor` to `value_blinder` [#214]
- Add `sender_enc` field to `TxOutputNote` [#214]
- Add `note_pk` field to `TxOutputNote` [#214]
- Add `sender_pk`, `signatures`, `output_npk` and `sender_blinder` fields to `TxCircuit` [#214]
- Remove `ViewKey` from `TxOutputNote::new()` parameters [#191]
- Make `rng` the first param in `TxInputNote::new` [#189]
- Rename `crossover` to `deposit` [#190]
- Remove recomputation of `value_commitment` in `TxOutputNote::New()`
- Rename `skeleton_hash` to `payload_hash` [#188]
- Make `TxCircuit` to use the Recipient gadget

### Removed

- Remove `WitnessTxOutputNote` struct [#214]
- Remove `RecipientParameters` struct [#214]
- Remove `elgamal::encrypt` and `elgamal::decrypt`

[0.2.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.1.0...circuits_v0.2.0
[0.29.0]: https://github.com/dusk-network/phoenix/compare/v0.28.1...v0.29.0
