### PR TITLE
core: Change `owns` to take a `StealthAddress`

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Let `owns` take a `StealthAddress` instead of a `Note`
 - Rename `tx_max_fee` to `max_fee` [#214]
 - Add `sender_enc` field to the `Note` [#214]
 - Add `sender_blinder` parameter for `Note` contructors [#214]

--- a/core/src/keys/secret.rs
+++ b/core/src/keys/secret.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::{keys::hash, Note, StealthAddress};
+use crate::{keys::hash, StealthAddress};
 
 use dusk_jubjub::{JubJubScalar, GENERATOR_EXTENDED};
 use ff::Field;
@@ -88,16 +88,14 @@ impl SecretKey {
     }
 
     /// Checks if `note_pk ?= (H(R · a) + b) · G`
-    pub fn owns(&self, note: &Note) -> bool {
-        let stealth = note.stealth_address();
-
-        let aR = stealth.R() * self.a();
+    pub fn owns(&self, stealth_address: &StealthAddress) -> bool {
+        let aR = stealth_address.R() * self.a();
         let hash_aR = hash(&aR);
         let note_sk = hash_aR + self.b();
 
         let note_pk = GENERATOR_EXTENDED * note_sk;
 
-        stealth.note_pk().as_ref() == &note_pk
+        stealth_address.note_pk().as_ref() == &note_pk
     }
 }
 

--- a/core/src/keys/view.rs
+++ b/core/src/keys/view.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::{keys::hash, Note, SecretKey};
+use crate::{keys::hash, SecretKey, StealthAddress};
 
 use dusk_bytes::{DeserializableSlice, Error, Serializable};
 use dusk_jubjub::{
@@ -63,15 +63,13 @@ impl ViewKey {
     }
 
     /// Checks `note_pk = H(R · a) · G + B`
-    pub fn owns(&self, note: &Note) -> bool {
-        let stealth = note.stealth_address();
-
-        let aR = stealth.R() * self.a();
+    pub fn owns(&self, stealth_address: &StealthAddress) -> bool {
+        let aR = stealth_address.R() * self.a();
         let hash_aR = hash(&aR);
         let hash_aR_G = GENERATOR_EXTENDED * hash_aR;
         let note_pk = hash_aR_G + self.B();
 
-        stealth.note_pk().as_ref() == &note_pk
+        stealth_address.note_pk().as_ref() == &note_pk
     }
 }
 

--- a/core/tests/keys.rs
+++ b/core/tests/keys.rs
@@ -79,8 +79,8 @@ fn keys_consistency() {
         sender_blinder,
     );
 
-    assert!(receiver_vk.owns(&note));
-    assert!(receiver_sk.owns(&note));
+    assert!(receiver_vk.owns(note.stealth_address()));
+    assert!(receiver_sk.owns(note.stealth_address()));
 
     let wrong_sk = SecretKey::random(&mut rng);
     let wrong_vk = ViewKey::from(&wrong_sk);
@@ -88,8 +88,8 @@ fn keys_consistency() {
     assert_ne!(receiver_sk, wrong_sk);
     assert_ne!(receiver_vk, wrong_vk);
 
-    assert!(!wrong_vk.owns(&note));
-    assert!(!wrong_sk.owns(&note));
+    assert!(!wrong_vk.owns(note.stealth_address()));
+    assert!(!wrong_sk.owns(note.stealth_address()));
 
     let sa = receiver_pk.gen_stealth_address(&r);
 


### PR DESCRIPTION
These changes are required after the deletion of the `Ownable` trait, in order for the functions to take both `Note`s and `License`s