### PR TITLE
Release core 0.30.0-rc.0 and circuits 0.2.1-rc.0

### DIFF
--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make `TxInputNote` fields public
+
 ## [0.2.0] - 2024-06-19
 
 ### Added

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-circuits"
-version = "0.2.0"
+version = "0.2.1-rc.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/circuits"
 description = "Circuit definitions for Phoenix, a privacy-preserving ZKP-based transaction model"
@@ -10,7 +10,7 @@ exclude = [".github/workflows/dusk-ci.yml", ".gitignore"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-phoenix-core = { version = "0.29.0-rc", default-features = false, path = "../core" }
+phoenix-core = { version = "0.30.0-rc", default-features = false, path = "../core" }
 dusk-plonk = { version = "0.19", default-features = false }
 dusk-jubjub = { version = "0.14", default-features = false }
 poseidon-merkle = { version = "0.6", features = ["rkyv-impl", "zk", "size_32"] }

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,11 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `Sender` struct [#222]
+
+### Changed
+
+- Let `owns` take a `StealthAddress` instead of a `Note`
+
 ## [0.29.0] - 2024-06-19
 
 ### Added
 
-- Add `Sender` struct [#222]
 - Add `encrypt_sender` function to encrypt the sender with the npk [#214]
 - Add `decrypt_sender` method to the `Note` [#214]
 - Add `elgamal::encrypt` and `elgamal::decrypt`
@@ -22,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Let `owns` take a `StealthAddress` instead of a `Note`
 - Rename `tx_max_fee` to `max_fee` [#214]
 - Add `sender_enc` field to the `Note` [#214]
 - Add `sender_blinder` parameter for `Note` contructors [#214]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.29.0"
+version = "0.30.0-rc.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/core"
 description = "Core types and functionalities for Phoenix, a privacy-preserving ZKP-based transaction model"


### PR DESCRIPTION
## core

### Added

- Add `Sender` struct [#222]

### Changed

- Let `owns` take a `StealthAddress` instead of a `Note`

## circuits

### Changed

- Make `TxInputNote` fields public
