### PR TITLE
Release: core v0.30.0, circuits v0.2.1

### DIFF
--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2024-07-03
+
 ### Changed
 
 - Make `TxInputNote` fields public
@@ -66,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#169]: https://github.com/dusk-network/phoenix/issues/169
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/phoenix/compare/circuits_v0.1.0...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix/compare/circuits_v0.2.1...HEAD
+[0.2.1]: https://github.com/dusk-network/phoenix/compare/circuits_v0.2.0...circuits_v0.2.1
 [0.2.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.1.0...circuits_v0.2.0
 [0.1.0]: https://github.com/dusk-network/phoenix/releases/tag/circuits_v0.1.0

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-circuits"
-version = "0.2.1-rc.0"
+version = "0.2.1"
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/circuits"
 description = "Circuit definitions for Phoenix, a privacy-preserving ZKP-based transaction model"
@@ -10,7 +10,7 @@ exclude = [".github/workflows/dusk-ci.yml", ".gitignore"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-phoenix-core = { version = "0.30.0-rc", default-features = false, path = "../core" }
+phoenix-core = { version = "0.30", default-features = false, path = "../core" }
 dusk-plonk = { version = "0.19", default-features = false }
 dusk-jubjub = { version = "0.14", default-features = false }
 poseidon-merkle = { version = "0.6", features = ["rkyv-impl", "zk", "size_32"] }

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.0] - 2024-07-03
+
 ### Added
 
 - Add `Sender` struct [#222]
@@ -398,7 +400,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#61]: https://github.com/dusk-network/phoenix/issues/61
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.29.0...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.30.0...HEAD
+[0.30.0]: https://github.com/dusk-network/phoenix/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/dusk-network/phoenix/compare/v0.28.1...v0.29.0
 [0.28.1]: https://github.com/dusk-network/phoenix/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/dusk-network/phoenix/compare/v0.27.0...v0.28.0

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.30.0-rc.0"
+version = "0.30.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/core"
 description = "Core types and functionalities for Phoenix, a privacy-preserving ZKP-based transaction model"


### PR DESCRIPTION
## core: [0.30.0] - 2024-07-03

### Added

- Add `Sender` struct [#222]

### Changed

- Let `owns` take a `StealthAddress` instead of a `Note`



## circuits: [0.2.1] - 2024-07-03

### Changed

- Make `TxInputNote` fields public




[0.30.0]: https://github.com/dusk-network/phoenix/compare/v0.29.0...v0.30.0
[0.2.1]: https://github.com/dusk-network/phoenix/compare/circuits_v0.2.0...circuits_v0.2.1
