### PR TITLE
Release core@0.31.0-rc.0 and circuits@0.3.0-rc.0

### DIFF
--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-circuits"
-version = "0.2.1"
+version = "0.3.0-rc.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/circuits"
 description = "Circuit definitions for Phoenix, a privacy-preserving ZKP-based transaction model"
@@ -11,7 +11,7 @@ exclude = [".github/workflows/dusk-ci.yml", ".gitignore"]
 
 [dependencies]
 dusk-bytes = "0.1"
-phoenix-core = { version = "0.30", default-features = false, path = "../core" }
+phoenix-core = { version = "0.31.0-rc.0", default-features = false, path = "../core" }
 dusk-bls12_381 = { version = "0.13", default-features = false }
 dusk-jubjub = { version = "0.14", default-features = false }
 poseidon-merkle = { version = "0.6" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.30.0"
+version = "0.31.0-rc.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/core"
 description = "Core types and functionalities for Phoenix, a privacy-preserving ZKP-based transaction model"


### PR DESCRIPTION
# core

### Added

- impl `Eq` for `StealthAddress`
- impl `Eq` for `TxSkeleton`

### Changed

- Update `bls12_381-bls` dep to 0.4


# circuits

### Removed

- Delete `TxInputNoteWitness` struct [#229]
- Delete `TxCircuit::new` constructor [#229]
- Delete `TxOutputNote::new` constructor [#229]

### Changed

- Make all `TxCircuit` fields public [#229]
- Make all `TxOutputNote` fields public [#229]
- Move `sender_blinder` field from `TxCircuit` to `TxOutputNote` [#229]
- Move `TxCircuit` from `transaction` module to root module [#229]
- Rename `TxInputNote` to `InputNoteInfo` [#229]
- Rename `TxOutputNote` to `OutputNoteInfo` [#229]
- Move `ff` and `rand` dependencies to dev-dependencies [#235]

### Added

- Add `dusk-bytes` dependency at v0.1 [#232]
- Add `TxCircuit::from_slice` and `TxCircuit::to_var_bytes` [#232]
- Add `InputNoteInfo::from_slice` and `InputNoteInfo::to_var_bytes` [#232]
- Add `Serializable` trait implementation for `OutputNoteInfo` [#232]
- Add `Clone` and `PartialEq` derives for `TxCircuit` [#232]
- Add `PartialEq` derive for `InputNoteInfo` [#232]
- Add associated const `TxCircuit::SIZE`
- Add associated const `InputNoteInfo::SIZE`
- Add `PartialEq` derive for `OutputNoteInfo` [#232]
- Add `dusk-bls12_381` dependency [#235]
- Add `"plonk"` feature to add the `dusk-plonk` dependency [#235]
- Add `"plonk"` feature as default feature [#235]
