### PR TITLE
Release core v0.31.0 and circuits v0.3.0

### DIFF
--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2024-08-14
+
 ### Removed
 
 - Delete `TxInputNoteWitness` struct [#229]
@@ -105,7 +107,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#169]: https://github.com/dusk-network/phoenix/issues/169
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/phoenix/compare/circuits_v0.2.1...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix/compare/circuits_v0.3.0...HEAD
+[0.3.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.2.1...circuits_v0.3.0
 [0.2.1]: https://github.com/dusk-network/phoenix/compare/circuits_v0.2.0...circuits_v0.2.1
 [0.2.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.1.0...circuits_v0.2.0
 [0.1.0]: https://github.com/dusk-network/phoenix/releases/tag/circuits_v0.1.0

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-circuits"
-version = "0.3.0-rc.0"
+version = "0.3.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/circuits"
 description = "Circuit definitions for Phoenix, a privacy-preserving ZKP-based transaction model"
@@ -11,7 +11,7 @@ exclude = [".github/workflows/dusk-ci.yml", ".gitignore"]
 
 [dependencies]
 dusk-bytes = "0.1"
-phoenix-core = { version = "0.31.0-rc.0", default-features = false, path = "../core" }
+phoenix-core = { version = "0.31", default-features = false, path = "../core" }
 dusk-bls12_381 = { version = "0.13", default-features = false }
 dusk-jubjub = { version = "0.14", default-features = false }
 poseidon-merkle = { version = "0.6" }

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.0] - 2024-08-14
+
 ### Added
 
 - impl `Eq` for `StealthAddress`
@@ -414,7 +416,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#61]: https://github.com/dusk-network/phoenix/issues/61
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.30.0...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.31.0...HEAD
+[0.31.0]: https://github.com/dusk-network/phoenix/compare/v0.30.0...v0.31.0
 [0.30.0]: https://github.com/dusk-network/phoenix/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/dusk-network/phoenix/compare/v0.28.1...v0.29.0
 [0.28.1]: https://github.com/dusk-network/phoenix/compare/v0.28.0...v0.28.1

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.31.0-rc.0"
+version = "0.31.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/core"
 description = "Core types and functionalities for Phoenix, a privacy-preserving ZKP-based transaction model"


### PR DESCRIPTION
# core

## [0.31.0] - 2024-08-14

### Added

- impl `Eq` for `StealthAddress`
- impl `Eq` for `TxSkeleton`

### Changed

- Update `bls12_381-bls` dep to 0.4

### Fixed

- Fix panic when attempting to decrypt the note with an incorrect view-key [#240]


# circuits

## [0.3.0] - 2024-08-14

### Removed

- Delete `TxInputNoteWitness` struct [#229]
- Delete `TxCircuit::new` constructor [#229]
- Delete `TxOutputNote::new` constructor [#229]

### Changed

- Make all `TxCircuit` fields public [#229]
- Make all `TxOutputNote` fields public [#229]
- Move `sender_blinder` field from `TxCircuit` to `TxOutputNote` [#229]
- Move `TxCircuit` from `transaction` module to root module [#229]
- Rename `TxInputNote` to `InputNoteInfo` [#229]
- Rename `TxOutputNote` to `OutputNoteInfo` [#229]
- Move `ff` and `rand` dependencies to dev-dependencies [#235]

### Added

- Add `dusk-bytes` dependency at v0.1 [#232]
- Add `TxCircuit::from_slice` and `TxCircuit::to_var_bytes` [#232]
- Add `InputNoteInfo::from_slice` and `InputNoteInfo::to_var_bytes` [#232]
- Add `Serializable` trait implementation for `OutputNoteInfo` [#232]
- Add `Clone` and `PartialEq` derives for `TxCircuit` [#232]
- Add `PartialEq` derive for `InputNoteInfo` [#232]
- Add associated const `TxCircuit::SIZE`
- Add associated const `InputNoteInfo::SIZE`
- Add `PartialEq` derive for `OutputNoteInfo` [#232]
- Add `dusk-bls12_381` dependency [#235]
- Add `"plonk"` feature to add the `dusk-plonk` dependency [#235]
- Add `"plonk"` feature as default feature [#235]
- Add `"rkyv-impl"` feature
- Add rkyv dependencies behind `rkyv-impl` feature
- Add rkyv derives for `TxCircuit`, `InputNoteInfo` and `OutputNoteInfo`



[0.31.0]: https://github.com/dusk-network/phoenix/compare/v0.30.0...v0.31.0

[0.3.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.2.1...circuits_v0.3.0
