### PR TITLE
Release core v0.32.0 and circuits v0.4.0

### DIFF
--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2024-08-14
+
+### Changed
+
+- Update dusk-plonk to v0.20
+- Update dusk-poseidon to v0.40
+- Update jubjub-schnorr to v0.5
+- Update poseidon-merkle to v0.7
+
 ## [0.3.0] - 2024-08-14
 
 ### Removed
@@ -107,7 +116,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#169]: https://github.com/dusk-network/phoenix/issues/169
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/phoenix/compare/circuits_v0.3.0...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix/compare/circuits_v0.4.0...HEAD
+[0.4.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.3.0...circuits_v0.4.0
 [0.3.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.2.1...circuits_v0.3.0
 [0.2.1]: https://github.com/dusk-network/phoenix/compare/circuits_v0.2.0...circuits_v0.2.1
 [0.2.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.1.0...circuits_v0.2.0

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-circuits"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/circuits"
 description = "Circuit definitions for Phoenix, a privacy-preserving ZKP-based transaction model"
@@ -11,15 +11,15 @@ exclude = [".github/workflows/dusk-ci.yml", ".gitignore"]
 
 [dependencies]
 dusk-bytes = "0.1"
-phoenix-core = { version = "0.31", default-features = false, path = "../core" }
+phoenix-core = { version = "0.32", default-features = false, path = "../core" }
 dusk-bls12_381 = { version = "0.13", default-features = false }
 dusk-jubjub = { version = "0.14", default-features = false }
-poseidon-merkle = { version = "0.6" }
-dusk-poseidon = { version = "0.39" }
-jubjub-schnorr = { version = "0.4" }
+poseidon-merkle = { version = "0.7" }
+dusk-poseidon = { version = "0.40" }
+jubjub-schnorr = { version = "0.5" }
 rkyv = { version = "0.7", default-features = false, optional = true }
 bytecheck = { version = "0.6", default-features = false, optional = true }
-dusk-plonk = { version = "0.19", default-features = false, optional = true }
+dusk-plonk = { version = "0.20", default-features = false, optional = true }
 
 [dev-dependencies]
 lazy_static = "1.4"

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.0] - 2024-08-14
+
+### Changed
+
+- Update dusk-poseidon to v0.40
+- Update jubjub-schnorr to v0.5
+
 ## [0.31.0] - 2024-08-14
 
 ### Added
@@ -416,7 +423,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#61]: https://github.com/dusk-network/phoenix/issues/61
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.31.0...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.32.0...HEAD
+[0.32.0]: https://github.com/dusk-network/phoenix/compare/v0.31.0...v0.32.0
 [0.31.0]: https://github.com/dusk-network/phoenix/compare/v0.30.0...v0.31.0
 [0.30.0]: https://github.com/dusk-network/phoenix/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/dusk-network/phoenix/compare/v0.28.1...v0.29.0

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/core"
 description = "Core types and functionalities for Phoenix, a privacy-preserving ZKP-based transaction model"
@@ -13,8 +13,8 @@ dusk-bytes = "0.1"
 dusk-bls12_381 = { version = "0.13", default-features = false }
 bls12_381-bls = { version = "0.4", default-features = false }
 dusk-jubjub = { version = "0.14", default-features = false, features = ["zeroize"] }
-dusk-poseidon = "0.39"
-jubjub-schnorr = "0.4"
+dusk-poseidon = "0.40"
+jubjub-schnorr = "0.5"
 subtle = { version = "^2.2.1", default-features = false }
 ff = { version = "0.13", default-features = false }
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc", "rand_core"] }


### PR DESCRIPTION
# core

## [0.32.0] - 2024-08-14

### Changed

- Update dusk-poseidon to v0.40
- Update jubjub-schnorr to v0.5

[0.32.0]: https://github.com/dusk-network/phoenix/compare/v0.31.0...v0.32.0

# circuits

## [0.4.0] - 2024-08-14

### Changed

- Update dusk-plonk to v0.20
- Update dusk-poseidon to v0.40
- Update jubjub-schnorr to v0.5
- Update poseidon-merkle to v0.7

[0.4.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.3.0...circuits_v0.4.0
