### PR TITLE
core: Avoid code duplication in `sk.owns` by calling `gen_note_sk`

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Call `gen_note_sk` in `SecretKey::owns` to avoid code duplication [#246]
+
 ## [0.32.0] - 2024-08-14
 
 ### Changed

--- a/core/src/keys/secret.rs
+++ b/core/src/keys/secret.rs
@@ -89,11 +89,9 @@ impl SecretKey {
 
     /// Checks if `note_pk ?= (H(R · a) + b) · G`
     pub fn owns(&self, stealth_address: &StealthAddress) -> bool {
-        let aR = stealth_address.R() * self.a();
-        let hash_aR = hash(&aR);
-        let note_sk = hash_aR + self.b();
+        let note_sk = self.gen_note_sk(stealth_address);
 
-        let note_pk = GENERATOR_EXTENDED * note_sk;
+        let note_pk = GENERATOR_EXTENDED * note_sk.as_ref();
 
         stealth_address.note_pk().as_ref() == &note_pk
     }


### PR DESCRIPTION
Resolves #246