### PR TITLE
Bump core and circuits

### DIFF
--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2024-12-18
+
 ### Added
 
 - Add jubjub-elgamal dependency [#255]
@@ -129,7 +131,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#169]: https://github.com/dusk-network/phoenix/issues/169
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/phoenix/compare/circuits_v0.4.0...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix/compare/circuits_v0.5.0...HEAD
+[0.5.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.4.0...circuits_v0.5.0
 [0.4.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.3.0...circuits_v0.4.0
 [0.3.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.2.1...circuits_v0.3.0
 [0.2.1]: https://github.com/dusk-network/phoenix/compare/circuits_v0.2.0...circuits_v0.2.1

--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add jubjub-elgamal dependency [#255]
 
+### Changed
+
+- Update phoenix-core to v0.33
+
 ### Removed
 
 - Remove elgamal encryption module [#255]

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [".github/workflows/dusk-ci.yml", ".gitignore"]
 
 [dependencies]
 dusk-bytes = "0.1"
-phoenix-core = { version = "0.32", default-features = false, path = "../core" }
+phoenix-core = { version = "0.33", default-features = false, path = "../core" }
 dusk-bls12_381 = { version = "0.13", default-features = false }
 dusk-jubjub = { version = "0.14", default-features = false }
 poseidon-merkle = "0.7"

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-circuits"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/circuits"
 description = "Circuit definitions for Phoenix, a privacy-preserving ZKP-based transaction model"

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,11 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Compute AES key using HKDF [#261]
-
-## [0.32.1] - 2024-12-17
+## [0.33.0] - 2024-12-18
 
 ### Added
 
@@ -25,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Call `gen_note_sk` in `SecretKey::owns` to avoid code duplication [#246]
 - `ViewKey` now checks both `a` and `B` in `ct_eq()`
+- Compute AES key using HKDF [#261]
 
 ### Removed
 
@@ -449,8 +446,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#61]: https://github.com/dusk-network/phoenix/issues/61
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.32.1...HEAD
-[0.32.1]: https://github.com/dusk-network/phoenix/compare/v0.32.0...v0.32.1
+[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.33.0...HEAD
+[0.33.0]: https://github.com/dusk-network/phoenix/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/dusk-network/phoenix/compare/v0.31.0...v0.32.0
 [0.31.0]: https://github.com/dusk-network/phoenix/compare/v0.30.0...v0.31.0
 [0.30.0]: https://github.com/dusk-network/phoenix/compare/v0.29.0...v0.30.0

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.32.1"
+version = "0.33.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/core"
 description = "Core types and functionalities for Phoenix, a privacy-preserving ZKP-based transaction model"


### PR DESCRIPTION
# core

## [0.33.0] - 2024-12-18

### Added

- Add jubjub-elgamal dependency [#255]
- Add serde `Serialize` and `Deserialize` implementations for `PublicKey`, `SecretKey`, `ViewKey`,
`NoteType`, `StealthAddress`, `Sender`, `Note` and `TxSkeleton` [#258]
- Add `serde`, `bs58`, `base64`, `hex` and `serde_json` optional dependencies [#258]
- Add `serde` feature [#258]

### Changed

- Call `gen_note_sk` in `SecretKey::owns` to avoid code duplication [#246]
- `ViewKey` now checks both `a` and `B` in `ct_eq()`
- Compute AES key using HKDF [#261]

### Removed

- Remove elgamal encryption module [#255]


# circuits

## [0.5.0] - 2024-12-18

### Added

- Add jubjub-elgamal dependency [#255]

### Changed

- Update phoenix-core to v0.33

### Removed

- Remove elgamal encryption module [#255]

[0.33.0]: https://github.com/dusk-network/phoenix/compare/v0.32.0...v0.33.0

[0.5.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.4.0...circuits_v0.5.0
