### PR TITLE
Release core `0.34.0` and circuits `0.6.0`

### DIFF
--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2025-02-07
+
 ### Changed
 
 - Update `dusk-bls12_381` to v0.14
@@ -141,7 +143,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#169]: https://github.com/dusk-network/phoenix/issues/169
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/phoenix/compare/circuits_v0.5.0...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix/compare/circuits_v0.6.0...HEAD
+[0.6.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.5.0...circuits_v0.6.0
 [0.5.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.4.0...circuits_v0.5.0
 [0.4.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.3.0...circuits_v0.4.0
 [0.3.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.2.1...circuits_v0.3.0

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-circuits"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/circuits"
 description = "Circuit definitions for Phoenix, a privacy-preserving ZKP-based transaction model"
@@ -11,7 +11,7 @@ exclude = [".github/workflows/dusk-ci.yml", ".gitignore"]
 
 [dependencies]
 dusk-bytes = "0.1"
-phoenix-core = { version = "0.33", default-features = false, path = "../core" }
+phoenix-core = { version = "0.34", default-features = false, path = "../core" }
 dusk-bls12_381 = { version = "0.14", default-features = false }
 dusk-jubjub = { version = "0.15", default-features = false }
 poseidon-merkle = "0.8"

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0] - 2024-02-07
+
 ### Changed
 
 - Removed suffix 'n' in serde serialization & deserialization of `u64`
@@ -461,7 +463,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#61]: https://github.com/dusk-network/phoenix/issues/61
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.33.1...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.34.0...HEAD
+[0.34.0]: https://github.com/dusk-network/phoenix/compare/v0.33.1...v0.34.0
 [0.33.1]: https://github.com/dusk-network/phoenix/compare/v0.33.0...v0.33.1
 [0.33.0]: https://github.com/dusk-network/phoenix/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/dusk-network/phoenix/compare/v0.31.0...v0.32.0

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.33.1"
+version = "0.34.0"
 edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/core"
 description = "Core types and functionalities for Phoenix, a privacy-preserving ZKP-based transaction model"


### PR DESCRIPTION
# core

## [0.34.0](https://github.com/dusk-network/phoenix/compare/v0.33.1...v0.34.0) - 2024-02-07

### Changed

- Removed suffix 'n' in serde serialization & deserialization of `u64`
- Update `dusk-bls12_381` to v0.14
- Update `dusk-jubjub` to v0.15
- Update `dusk-poseidon` to v0.41
- Update `jubjub-schnorr` to v0.6
- Update `jubjub-elgamal` to v0.2

# circuits

## [0.6.0](https://github.com/dusk-network/phoenix/compare/circuits_v0.5.0...circuits_v0.6.0) - 2025-02-07

### Changed

- Update `dusk-bls12_381` to v0.14
- Update `dusk-jubjub` to v0.15
- Update `poseidon-merkle` to v0.8
- Update `dusk-poseidon` to v0.41
- Update `jubjub-schnorr` to v0.6
- Update `jubjub-elgamal` to v0.2
- Update `dusk-plonk` to v0.21
