### PR TITLE
Release Phoenix core 0.35.1 and circuits 0.8.1

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -91,3 +91,23 @@ jobs:
       - uses: dsherret/rust-toolchain-file@v1
       - run: rustup target add wasm32-unknown-unknown
       - run: make test-no-std
+
+  no-std:
+    name: Bare-metal no_std
+    runs-on: core
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure git auth for private dependencies
+        run: |
+          if [ -z "${{ secrets.PLONK_PRIVATE_READ_TOKEN }}" ]; then
+            echo "PLONK_PRIVATE_READ_TOKEN is not configured"
+            exit 1
+          fi
+          export GIT_CONFIG_GLOBAL="${RUNNER_TEMP}/gitconfig"
+          echo "GIT_CONFIG_GLOBAL=${RUNNER_TEMP}/gitconfig" >> "$GITHUB_ENV"
+          git config --global url."https://x-access-token:${{ secrets.PLONK_PRIVATE_READ_TOKEN }}@github.com/".insteadOf "https://github.com/"
+          git config --local --unset-all http.https://github.com/.extraheader || true
+      - name: Add Rust tools to PATH
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - uses: dsherret/rust-toolchain-file@v1
+      - run: make no-std

--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -12,16 +12,6 @@ jobs:
     runs-on: core
     steps:
       - uses: actions/checkout@v4
-      - name: Configure git auth for private dependencies
-        run: |
-          if [ -z "${{ secrets.PLONK_PRIVATE_READ_TOKEN }}" ]; then
-            echo "PLONK_PRIVATE_READ_TOKEN is not configured"
-            exit 1
-          fi
-          export GIT_CONFIG_GLOBAL="${RUNNER_TEMP}/gitconfig"
-          echo "GIT_CONFIG_GLOBAL=${RUNNER_TEMP}/gitconfig" >> "$GITHUB_ENV"
-          git config --global url."https://x-access-token:${{ secrets.PLONK_PRIVATE_READ_TOKEN }}@github.com/".insteadOf "https://github.com/"
-          git config --local --unset-all http.https://github.com/.extraheader || true
       - name: Add Rust tools to PATH
         run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - uses: dsherret/rust-toolchain-file@v1
@@ -32,16 +22,6 @@ jobs:
     runs-on: core
     steps:
       - uses: actions/checkout@v4
-      - name: Configure git auth for private dependencies
-        run: |
-          if [ -z "${{ secrets.PLONK_PRIVATE_READ_TOKEN }}" ]; then
-            echo "PLONK_PRIVATE_READ_TOKEN is not configured"
-            exit 1
-          fi
-          export GIT_CONFIG_GLOBAL="${RUNNER_TEMP}/gitconfig"
-          echo "GIT_CONFIG_GLOBAL=${RUNNER_TEMP}/gitconfig" >> "$GITHUB_ENV"
-          git config --global url."https://x-access-token:${{ secrets.PLONK_PRIVATE_READ_TOKEN }}@github.com/".insteadOf "https://github.com/"
-          git config --local --unset-all http.https://github.com/.extraheader || true
       - name: Add Rust tools to PATH
         run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - uses: dsherret/rust-toolchain-file@v1
@@ -56,16 +36,6 @@ jobs:
     runs-on: core
     steps:
       - uses: actions/checkout@v4
-      - name: Configure git auth for private dependencies
-        run: |
-          if [ -z "${{ secrets.PLONK_PRIVATE_READ_TOKEN }}" ]; then
-            echo "PLONK_PRIVATE_READ_TOKEN is not configured"
-            exit 1
-          fi
-          export GIT_CONFIG_GLOBAL="${RUNNER_TEMP}/gitconfig"
-          echo "GIT_CONFIG_GLOBAL=${RUNNER_TEMP}/gitconfig" >> "$GITHUB_ENV"
-          git config --global url."https://x-access-token:${{ secrets.PLONK_PRIVATE_READ_TOKEN }}@github.com/".insteadOf "https://github.com/"
-          git config --local --unset-all http.https://github.com/.extraheader || true
       - name: Add Rust tools to PATH
         run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - uses: dsherret/rust-toolchain-file@v1
@@ -76,16 +46,6 @@ jobs:
     runs-on: core
     steps:
       - uses: actions/checkout@v4
-      - name: Configure git auth for private dependencies
-        run: |
-          if [ -z "${{ secrets.PLONK_PRIVATE_READ_TOKEN }}" ]; then
-            echo "PLONK_PRIVATE_READ_TOKEN is not configured"
-            exit 1
-          fi
-          export GIT_CONFIG_GLOBAL="${RUNNER_TEMP}/gitconfig"
-          echo "GIT_CONFIG_GLOBAL=${RUNNER_TEMP}/gitconfig" >> "$GITHUB_ENV"
-          git config --global url."https://x-access-token:${{ secrets.PLONK_PRIVATE_READ_TOKEN }}@github.com/".insteadOf "https://github.com/"
-          git config --local --unset-all http.https://github.com/.extraheader || true
       - name: Add Rust tools to PATH
         run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - uses: dsherret/rust-toolchain-file@v1
@@ -97,16 +57,6 @@ jobs:
     runs-on: core
     steps:
       - uses: actions/checkout@v4
-      - name: Configure git auth for private dependencies
-        run: |
-          if [ -z "${{ secrets.PLONK_PRIVATE_READ_TOKEN }}" ]; then
-            echo "PLONK_PRIVATE_READ_TOKEN is not configured"
-            exit 1
-          fi
-          export GIT_CONFIG_GLOBAL="${RUNNER_TEMP}/gitconfig"
-          echo "GIT_CONFIG_GLOBAL=${RUNNER_TEMP}/gitconfig" >> "$GITHUB_ENV"
-          git config --global url."https://x-access-token:${{ secrets.PLONK_PRIVATE_READ_TOKEN }}@github.com/".insteadOf "https://github.com/"
-          git config --local --unset-all http.https://github.com/.extraheader || true
       - name: Add Rust tools to PATH
         run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - uses: dsherret/rust-toolchain-file@v1

--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -7,57 +7,26 @@ on:
 name: Continuous integration
 
 jobs:
-  rustfmt:
-    name: Rust Format
-    runs-on: core
-    steps:
-      - uses: actions/checkout@v4
-      - name: Add Rust tools to PATH
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-      - uses: dsherret/rust-toolchain-file@v1
-      - run: cargo fmt --all -- --check
-
-  clippy:
-    name: Clippy Check
-    runs-on: core
-    steps:
-      - uses: actions/checkout@v4
-      - name: Add Rust tools to PATH
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-      - uses: dsherret/rust-toolchain-file@v1
-      - run: cargo clippy --release --features=alloc,serde -- -D warnings
-
-  dusk_analyzer:
-    name: Dusk Analyzer
-    uses: dusk-network/.github/.github/workflows/dusk-analysis.yml@main
+  code-quality:
+    name: Code quality
+    uses: dusk-network/.github/.github/workflows/run-make.yml@main
+    with:
+      make_target: cq
 
   test:
-    name: Tests
-    runs-on: core
-    steps:
-      - uses: actions/checkout@v4
-      - name: Add Rust tools to PATH
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-      - uses: dsherret/rust-toolchain-file@v1
-      - run: make test
+    name: Run tests
+    uses: dusk-network/.github/.github/workflows/run-make.yml@main
+    with:
+      make_target: test
 
   test-no-std:
     name: No-std checks
-    runs-on: core
-    steps:
-      - uses: actions/checkout@v4
-      - name: Add Rust tools to PATH
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-      - uses: dsherret/rust-toolchain-file@v1
-      - run: rustup target add wasm32-unknown-unknown
-      - run: make test-no-std
+    uses: dusk-network/.github/.github/workflows/run-make.yml@main
+    with:
+      make_target: test-no-std
 
   no-std:
     name: Bare-metal no_std
-    runs-on: core
-    steps:
-      - uses: actions/checkout@v4
-      - name: Add Rust tools to PATH
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-      - uses: dsherret/rust-toolchain-file@v1
-      - run: make no-std
+    uses: dusk-network/.github/.github/workflows/run-make.yml@main
+    with:
+      make_target: no-std

--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -51,8 +51,8 @@ jobs:
     name: Dusk Analyzer
     uses: dusk-network/.github/.github/workflows/dusk-analysis.yml@main
 
-  test_core:
-    name: test core
+  test:
+    name: Tests
     runs-on: core
     steps:
       - uses: actions/checkout@v4
@@ -69,90 +69,10 @@ jobs:
       - name: Add Rust tools to PATH
         run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - uses: dsherret/rust-toolchain-file@v1
-      - run: cargo test --release -p phoenix-core --features=alloc,serde
+      - run: make test
 
-  test_core_no_default_serde:
-    name: test core no-default-features serde
-    runs-on: core
-    steps:
-      - uses: actions/checkout@v4
-      - name: Configure git auth for private dependencies
-        run: |
-          if [ -z "${{ secrets.PLONK_PRIVATE_READ_TOKEN }}" ]; then
-            echo "PLONK_PRIVATE_READ_TOKEN is not configured"
-            exit 1
-          fi
-          export GIT_CONFIG_GLOBAL="${RUNNER_TEMP}/gitconfig"
-          echo "GIT_CONFIG_GLOBAL=${RUNNER_TEMP}/gitconfig" >> "$GITHUB_ENV"
-          git config --global url."https://x-access-token:${{ secrets.PLONK_PRIVATE_READ_TOKEN }}@github.com/".insteadOf "https://github.com/"
-          git config --local --unset-all http.https://github.com/.extraheader || true
-      - name: Add Rust tools to PATH
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-      - uses: dsherret/rust-toolchain-file@v1
-      - run: cargo test --release -p phoenix-core --no-default-features --features=serde
-
-  test_core_rkyv:
-    name: test core rkyv compiles
-    runs-on: core
-    steps:
-      - uses: actions/checkout@v4
-      - name: Configure git auth for private dependencies
-        run: |
-          if [ -z "${{ secrets.PLONK_PRIVATE_READ_TOKEN }}" ]; then
-            echo "PLONK_PRIVATE_READ_TOKEN is not configured"
-            exit 1
-          fi
-          export GIT_CONFIG_GLOBAL="${RUNNER_TEMP}/gitconfig"
-          echo "GIT_CONFIG_GLOBAL=${RUNNER_TEMP}/gitconfig" >> "$GITHUB_ENV"
-          git config --global url."https://x-access-token:${{ secrets.PLONK_PRIVATE_READ_TOKEN }}@github.com/".insteadOf "https://github.com/"
-          git config --local --unset-all http.https://github.com/.extraheader || true
-      - name: Add Rust tools to PATH
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-      - uses: dsherret/rust-toolchain-file@v1
-      - run: cargo test --release -p phoenix-core --features=rkyv-impl,alloc --no-run
-
-  test_circuits:
-    name: test cirucits
-    runs-on: core
-    steps:
-      - uses: actions/checkout@v4
-      - name: Configure git auth for private dependencies
-        run: |
-          if [ -z "${{ secrets.PLONK_PRIVATE_READ_TOKEN }}" ]; then
-            echo "PLONK_PRIVATE_READ_TOKEN is not configured"
-            exit 1
-          fi
-          export GIT_CONFIG_GLOBAL="${RUNNER_TEMP}/gitconfig"
-          echo "GIT_CONFIG_GLOBAL=${RUNNER_TEMP}/gitconfig" >> "$GITHUB_ENV"
-          git config --global url."https://x-access-token:${{ secrets.PLONK_PRIVATE_READ_TOKEN }}@github.com/".insteadOf "https://github.com/"
-          git config --local --unset-all http.https://github.com/.extraheader || true
-      - name: Add Rust tools to PATH
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-      - uses: dsherret/rust-toolchain-file@v1
-      - run: cargo test --release -p phoenix-circuits
-
-  test_circuits_no_default:
-    name: test cirucits no-default-features
-    runs-on: core
-    steps:
-      - uses: actions/checkout@v4
-      - name: Configure git auth for private dependencies
-        run: |
-          if [ -z "${{ secrets.PLONK_PRIVATE_READ_TOKEN }}" ]; then
-            echo "PLONK_PRIVATE_READ_TOKEN is not configured"
-            exit 1
-          fi
-          export GIT_CONFIG_GLOBAL="${RUNNER_TEMP}/gitconfig"
-          echo "GIT_CONFIG_GLOBAL=${RUNNER_TEMP}/gitconfig" >> "$GITHUB_ENV"
-          git config --global url."https://x-access-token:${{ secrets.PLONK_PRIVATE_READ_TOKEN }}@github.com/".insteadOf "https://github.com/"
-          git config --local --unset-all http.https://github.com/.extraheader || true
-      - name: Add Rust tools to PATH
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-      - uses: dsherret/rust-toolchain-file@v1
-      - run: cargo test --release -p phoenix-circuits --no-default-features --features=rkyv-impl,rkyv/size_16 --no-run
-
-  compiles_to_wasm_with_serde:
-    name: Compiles to wasm with serde enabled
+  test-no-std:
+    name: No-std checks
     runs-on: core
     steps:
       - uses: actions/checkout@v4
@@ -170,5 +90,4 @@ jobs:
         run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - uses: dsherret/rust-toolchain-file@v1
       - run: rustup target add wasm32-unknown-unknown
-      - run: cargo b --release --no-default-features --features serde --target wasm32-unknown-unknown
-        working-directory: core
+      - run: make test-no-std

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,5 +114,25 @@ Phoenix uses a **UTXO model** where:
 ## Git Conventions
 
 - Default branch: `master`
-- Commit messages: concise, imperative mood (e.g. "add Makefile targets for CI parity")
 - License: MPL-2.0
+
+### Commit messages
+
+Format: `<scope>: <Description>` — imperative mood, capitalize first word after colon.
+
+**One commit per crate per concern.** Each commit touches exactly one crate and one logical concern. Never bundle changes to different crates in one commit, and don't mix unrelated changes within the same crate either. Order commits bottom-up through the dependency chain (`core` before `circuits`).
+
+Canonical scopes:
+
+| Scope | Directory |
+|-------|-----------|
+| `core` | `core/` |
+| `circuits` | `circuits/` |
+| `workspace` | Root `Cargo.toml`, root Makefile |
+| `ci` | `.github/workflows/` |
+| `docs` | Documentation-only changes |
+
+Examples:
+- `core: Add serde support for ContractCall`
+- `circuits: Fix TxCircuit witness generation`
+- `workspace: Update dusk dependencies`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,118 @@
+# Phoenix
+
+Phoenix is the privacy-preserving transaction model used by Dusk. It implements a UTXO-based architecture with obfuscated transactions using zero-knowledge proofs.
+
+In Phoenix, coins are stored as encrypted notes in a Merkle tree. Transactions consume existing notes and produce new ones, using nullifiers to prevent double spending without revealing which notes were spent.
+
+## Repository Map
+
+```
+phoenix/
+├── core/          # phoenix-core — core types: keys, notes, stealth addresses, transactions
+├── circuits/      # phoenix-circuits — ZKP circuit definitions (PLONK-based)
+├── docs/          # Protocol specifications (v1, v2)
+└── Makefile       # Root Makefile delegating to member crates
+```
+
+### `core/` (`phoenix-core`)
+
+Core library providing the fundamental Phoenix types:
+
+- **Keys**: `SecretKey`, `PublicKey`, `ViewKey` — key derivation and management
+- **Notes**: `Note`, `NoteType`, `Sender` — the UTXO type with encryption
+- **Stealth addresses**: `StealthAddress` — one-time addresses for recipient privacy
+- **Transactions**: `TxSkeleton` — transaction structure (requires `alloc` feature)
+- **Encryption**: AES-GCM encryption for note data
+- **Value commitments**: Pedersen commitment scheme for hiding transaction values
+
+### `circuits/` (`phoenix-circuits`)
+
+Zero-knowledge circuit definitions for proving transaction validity:
+
+- `TxCircuit` — main transaction circuit with configurable tree height (`H`) and input count (`I`)
+- `InputNoteInfo` / `OutputNoteInfo` — circuit witness data for notes
+- Sender encryption gadget
+- Built on `dusk-plonk` (gated behind the `plonk` feature)
+
+## Commands
+
+```bash
+make test          # Run all tests (core + circuits, --release)
+make test-no-std   # Verify no_std compilation (rkyv, wasm targets)
+make no-std        # Verify bare-metal target compatibility (thumbv6m-none-eabi)
+make clippy        # Run clippy on all crates
+make fmt           # Format code (requires nightly toolchain)
+make doc           # Generate documentation
+make clean         # Clean build artifacts
+```
+
+Tests **must** use `--release` because phoenix depends on `dusk-plonk` — debug builds take extremely long for PLONK proofs.
+
+## Feature Flags
+
+### `phoenix-core`
+
+| Feature    | Description                                             | Default |
+|------------|---------------------------------------------------------|---------|
+| `alloc`    | Enables `TxSkeleton` and heap-allocated types           | Yes     |
+| `rkyv-impl`| rkyv serialization (enables rkyv on jubjub, bls12_381) | No      |
+| `serde`    | serde + JSON support (implies `alloc`)                  | No      |
+
+### `phoenix-circuits`
+
+| Feature    | Description                                             | Default |
+|------------|---------------------------------------------------------|---------|
+| `plonk`   | Enables circuit implementations via `dusk-plonk`         | Yes     |
+| `rkyv-impl`| rkyv serialization for circuit types                    | No      |
+
+## Architecture
+
+### Privacy Model
+
+Phoenix uses a **UTXO model** where:
+
+1. Notes are hashed and stored in a **Merkle tree of notes**
+2. Spending a note requires proving ownership via zero-knowledge proof without revealing which note is spent
+3. **Nullifiers** are deterministic values that invalidate spent notes — they cannot be linked to specific notes by external observers
+4. **Stealth addresses** provide recipient privacy via one-time addresses
+5. **Value commitments** (Pedersen scheme) hide transaction amounts
+
+### Transaction Flow
+
+1. Sender selects input notes and generates Merkle openings
+2. `TxCircuit` proves: ownership of inputs, correct nullifier computation, balance (inputs = outputs + fee + deposit), and sender encryption
+3. Output notes are encrypted for recipients
+4. The network verifies the proof and adds nullifiers to the spent set
+
+### Key Dependencies
+
+- `dusk-plonk` — PLONK proving system (private repo, requires auth token)
+- `dusk-jubjub` — JubJub elliptic curve (key derivation, stealth addresses)
+- `dusk-bls12_381` — BLS12-381 curve (scalars used in Merkle tree, circuit)
+- `dusk-poseidon` — Poseidon hash (note hashing, Merkle tree)
+- `poseidon-merkle` — Merkle tree implementation
+- `jubjub-schnorr` — Schnorr signatures (transaction authorization)
+- `jubjub-elgamal` — ElGamal encryption (sender encryption in circuits)
+
+## Conventions
+
+- **`no_std`**: Both crates are `no_std`. Do not add `std` dependencies.
+- **Serialization**: Use `dusk-bytes` for canonical byte encoding, `rkyv` for zero-copy deserialization (feature-gated), `serde` for JSON (feature-gated).
+- **Field ordering**: Do not reorder fields in `rkyv`-serializable structs — it breaks archive compatibility.
+- **Constant-time**: Operations on secret data (keys, blinding factors) must remain constant-time. Do not introduce branches or early returns on secrets.
+- **Edition 2024**: The workspace uses Rust edition 2024 with MSRV 1.85.
+
+## Change Propagation
+
+`phoenix-core` and `phoenix-circuits` are used by downstream crates in the Dusk ecosystem:
+
+| Changed crate     | Also verify                                |
+|--------------------|--------------------------------------------|
+| `phoenix-core`     | `phoenix-circuits`, `rusk/contracts`, `rusk/wallet-core`, `rusk/vm` |
+| `phoenix-circuits` | `rusk-prover`, `rusk`                      |
+
+## Git Conventions
+
+- Default branch: `master`
+- Commit messages: concise, imperative mood (e.g. "add Makefile targets for CI parity")
+- License: MPL-2.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,3 @@ resolver = "2"
 rust-version = "1.85"
 license = "MPL-2.0"
 edition = "2024"
-
-[patch.crates-io]
-jubjub-elgamal = { git = "https://github.com/dusk-network/jubjub-elgamal-private.git", tag = "AEGIS" }

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,13 @@ clippy: ## Run clippy
 	@$(MAKE) -C ./core $@
 	@$(MAKE) -C ./circuits $@
 
+cq: ## Run code quality checks (formatting + clippy)
+	@$(MAKE) fmt CHECK=1
+	@$(MAKE) clippy
+
 fmt: ## Format code (requires nightly)
-	@cargo +nightly fmt --all
+	@rustup component add --toolchain nightly rustfmt 2>/dev/null || true
+	@cargo +nightly fmt --all $(if $(CHECK),-- --check,)
 
 doc: ## Generate documentation
 	@cargo doc --no-deps
@@ -27,4 +32,4 @@ doc: ## Generate documentation
 clean: ## Clean build artifacts
 	@cargo clean
 
-.PHONY: help test test-no-std no-std clippy fmt doc clean
+.PHONY: help test test-no-std no-std clippy cq fmt doc clean

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+help: ## Display this help screen
+	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run all tests
+	@$(MAKE) -C ./core $@
+	@$(MAKE) -C ./circuits $@
+
+test-no-std: ## Verify no_std compilation
+	@$(MAKE) -C ./core $@
+	@$(MAKE) -C ./circuits $@
+
+no-std: ## Verify no_std compatibility on bare-metal target
+	@$(MAKE) -C ./core $@
+	@$(MAKE) -C ./circuits $@
+
+clippy: ## Run clippy
+	@$(MAKE) -C ./core $@
+	@$(MAKE) -C ./circuits $@
+
+fmt: ## Format code (requires nightly)
+	@cargo +nightly fmt --all
+
+doc: ## Generate documentation
+	@cargo doc --no-deps
+
+clean: ## Clean build artifacts
+	@cargo clean
+
+.PHONY: help test test-no-std no-std clippy fmt doc clean

--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Move to edition 2024
 - Move to stable MSRV 1.85
-- Update `dusk-plonk` to v0.22.0-rc.0
+- Update `dusk-plonk` to v0.22.0
 - Update `poseidon-merkle` to v0.9.0-rc.0
 - Update `dusk-poseidon` to v0.42.0-rc.0
 - Update `jubjub-schnorr` to v0.7.0-rc.0

--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-02-27
+
 ### Changed
 
 - Move to edition 2024
@@ -15,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `poseidon-merkle` to v0.9.0-rc.0
 - Update `dusk-poseidon` to v0.42.0-rc.0
 - Update `jubjub-schnorr` to v0.7.0-rc.0
-- Update `jubjub-elgamal` to v0.5.0-rc.1
+- Update `jubjub-elgamal` to v0.5.0
 - Use `encrypt_unchecked` elgamal gadget [#280]
 
 ## [0.6.0] - 2025-02-07
@@ -154,7 +156,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#169]: https://github.com/dusk-network/phoenix/issues/169
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/phoenix/compare/circuits_v0.6.0...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix/compare/circuits_v0.8.0...HEAD
+[0.8.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.6.0...circuits_v0.8.0
 [0.6.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.5.0...circuits_v0.6.0
 [0.5.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.4.0...circuits_v0.5.0
 [0.4.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.3.0...circuits_v0.4.0

--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-06-15
+
+### Changed
+
+- Update `phoenix-core` to v0.35.1
+- Update `dusk-plonk` to v0.22.1
+
 ## [0.8.0] - 2026-02-27
 
 ### Changed
@@ -156,7 +163,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#169]: https://github.com/dusk-network/phoenix/issues/169
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/phoenix/compare/circuits_v0.8.0...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix/compare/circuits_v0.8.1...HEAD
+[0.8.1]: https://github.com/dusk-network/phoenix/compare/circuits_v0.8.0...circuits_v0.8.1
 [0.8.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.6.0...circuits_v0.8.0
 [0.6.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.5.0...circuits_v0.6.0
 [0.5.0]: https://github.com/dusk-network/phoenix/compare/circuits_v0.4.0...circuits_v0.5.0

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -22,7 +22,7 @@ jubjub-schnorr = "0.7.0-rc.0"
 jubjub-elgamal = "0.5.0"
 rkyv = { version = "0.7", default-features = false, optional = true }
 bytecheck = { version = "0.6", default-features = false, optional = true }
-dusk-plonk = { version = "0.22.0-rc.0", default-features = false, optional = true }
+dusk-plonk = { version = "0.22.0", default-features = false, optional = true }
 
 [dev-dependencies]
 lazy_static = "1.4"

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-circuits"
-version = "0.8.0-rc.0"
+version = "0.8.0"
 repository = "https://github.com/dusk-network/phoenix/circuits"
 description = "Circuit definitions for Phoenix, a privacy-preserving ZKP-based transaction model"
 exclude = [".github/workflows/dusk-ci.yml", ".gitignore"]
@@ -13,13 +13,13 @@ edition.workspace = true
 
 [dependencies]
 dusk-bytes = "0.1"
-phoenix-core = { version = "0.35.0-rc.0", default-features = false, path = "../core" }
+phoenix-core = { version = "0.35.0", default-features = false, path = "../core" }
 dusk-bls12_381 = { version = "0.14", default-features = false }
 dusk-jubjub = { version = "0.15", default-features = false }
 poseidon-merkle = "0.9.0-rc.0"
 dusk-poseidon = "0.42.0-rc.0"
 jubjub-schnorr = "0.7.0-rc.0"
-jubjub-elgamal = "0.5.0-rc.1"
+jubjub-elgamal = "0.5.0"
 rkyv = { version = "0.7", default-features = false, optional = true }
 bytecheck = { version = "0.6", default-features = false, optional = true }
 dusk-plonk = { version = "0.22.0-rc.0", default-features = false, optional = true }

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-circuits"
-version = "0.8.0"
+version = "0.8.1"
 repository = "https://github.com/dusk-network/phoenix/circuits"
 description = "Circuit definitions for Phoenix, a privacy-preserving ZKP-based transaction model"
 exclude = [".github/workflows/dusk-ci.yml", ".gitignore"]
@@ -13,7 +13,7 @@ edition.workspace = true
 
 [dependencies]
 dusk-bytes = "0.1"
-phoenix-core = { version = "0.35.0", default-features = false, path = "../core" }
+phoenix-core = { version = "0.35.1", default-features = false, path = "../core" }
 dusk-bls12_381 = { version = "0.14", default-features = false }
 dusk-jubjub = { version = "0.15", default-features = false }
 poseidon-merkle = "0.9.0-rc.0"
@@ -22,7 +22,7 @@ jubjub-schnorr = "0.7.0-rc.0"
 jubjub-elgamal = "0.5.0"
 rkyv = { version = "0.7", default-features = false, optional = true }
 bytecheck = { version = "0.6", default-features = false, optional = true }
-dusk-plonk = { version = "0.22.0", default-features = false, optional = true }
+dusk-plonk = { version = "0.22.1", default-features = false, optional = true }
 
 [dev-dependencies]
 lazy_static = "1.4"

--- a/circuits/Makefile
+++ b/circuits/Makefile
@@ -14,5 +14,6 @@ no-std: ## Verify no_std compatibility on bare-metal target
 
 clippy: ## Run clippy
 	@cargo clippy --release -- -D warnings
+	@cargo clippy --release --no-default-features -- -D warnings
 
 .PHONY: help test test-no-std no-std clippy

--- a/circuits/Makefile
+++ b/circuits/Makefile
@@ -1,0 +1,18 @@
+help: ## Display this help screen
+	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run circuit tests
+	@cargo test --release
+
+test-no-std: ## Verify no_std compilation
+	@cargo test --release --no-default-features --features=rkyv-impl,rkyv/size_16 --no-run
+
+no-std: ## Verify no_std compatibility on bare-metal target
+	@rustup target add thumbv6m-none-eabi
+	@cargo build --release --no-default-features --target thumbv6m-none-eabi
+
+clippy: ## Run clippy
+	@cargo clippy --release -- -D warnings
+
+.PHONY: help test test-no-std no-std clippy

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -19,12 +19,10 @@ use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
 use dusk_jubjub::{JubJubAffine, JubJubScalar};
 use jubjub_schnorr::{Signature as SchnorrSignature, SignatureDouble};
+use phoenix_core::{Note, OUTPUT_NOTES, PublicKey, SecretKey};
 use poseidon_merkle::{ARITY, Item, Opening, Tree};
-
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize, Serialize};
-
-use phoenix_core::{Note, OUTPUT_NOTES, PublicKey, SecretKey};
 
 extern crate alloc;
 use alloc::vec::Vec;

--- a/circuits/tests/common/mod.rs
+++ b/circuits/tests/common/mod.rs
@@ -8,10 +8,6 @@ use std::fs;
 use std::io::Read;
 use std::path::PathBuf;
 
-use rand::SeedableRng;
-use rand::rngs::StdRng;
-use rand::{CryptoRng, RngCore};
-
 use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{GENERATOR_NUMS_EXTENDED, JubJubAffine, JubJubScalar};
 use dusk_plonk::prelude::PublicParameters;
@@ -20,13 +16,14 @@ use jubjub_elgamal::Encryption as ElGamal;
 use jubjub_schnorr::{
     SecretKey as SchnorrSecretKey, Signature as SchnorrSignature,
 };
-use poseidon_merkle::{Item, Tree};
-use sha2::{Digest, Sha256};
-
 pub use phoenix_circuits::{InputNoteInfo, OutputNoteInfo};
 use phoenix_core::{
     Note, OUTPUT_NOTES, PublicKey, SecretKey, ViewKey, value_commitment,
 };
+use poseidon_merkle::{Item, Tree};
+use rand::rngs::StdRng;
+use rand::{CryptoRng, RngCore, SeedableRng};
+use sha2::{Digest, Sha256};
 
 const CRS_URL: &str = "https://testnet.nodes.dusk.network/trusted-setup";
 const CRS_HASH: &str =

--- a/circuits/tests/serialization.rs
+++ b/circuits/tests/serialization.rs
@@ -4,19 +4,16 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use rand::SeedableRng;
-use rand::rngs::StdRng;
-use rand::{CryptoRng, Rng, RngCore};
-
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{Error as BytesError, Serializable};
 use dusk_jubjub::{GENERATOR_EXTENDED, JubJubAffine, JubJubScalar};
 use ff::Field;
 use jubjub_schnorr::{Signature as SchnorrSignature, SignatureDouble};
-use poseidon_merkle::{Item, Tree};
-
 use phoenix_circuits::{InputNoteInfo, OutputNoteInfo, TxCircuit};
 use phoenix_core::{Note, PublicKey, SecretKey};
+use poseidon_merkle::{Item, Tree};
+use rand::rngs::StdRng;
+use rand::{CryptoRng, Rng, RngCore, SeedableRng};
 
 const HEIGHT: usize = 17;
 

--- a/circuits/tests/serialization.rs
+++ b/circuits/tests/serialization.rs
@@ -99,7 +99,7 @@ fn random_circuit<const I: usize>(
     signature_1_bytes[..32]
         .copy_from_slice(&JubJubScalar::random(&mut *rng).to_bytes()[..]);
     // generate random signature_1.R
-    signature_0_bytes[32..]
+    signature_1_bytes[32..]
         .copy_from_slice(&random_jubjub_affine(rng).to_bytes()[..]);
 
     TxCircuit {

--- a/circuits/tests/transaction.rs
+++ b/circuits/tests/transaction.rs
@@ -6,12 +6,10 @@
 
 #![cfg(feature = "plonk")]
 
+use dusk_plonk::prelude::Compiler;
+use phoenix_circuits::TxCircuit;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
-
-use dusk_plonk::prelude::Compiler;
-
-use phoenix_circuits::TxCircuit;
 
 mod common;
 use common::*;

--- a/circuits/tests/verifier_data.rs
+++ b/circuits/tests/verifier_data.rs
@@ -14,12 +14,10 @@
 
 #![cfg(feature = "plonk")]
 
+use dusk_plonk::prelude::{Compiler, Verifier};
+use phoenix_circuits::TxCircuit;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
-
-use dusk_plonk::prelude::{Compiler, Verifier};
-
-use phoenix_circuits::TxCircuit;
 
 mod common;
 use common::*;

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix order-dependent deserialization of `Note` [#274]
+- Preserve compatibility when decoding historical Phoenix transactions after
+  stricter `dusk-jubjub` subgroup checks.
 - Bound `TxSkeleton::from_slice` nullifier allocation to reject malformed
   oversized nullifier counts before allocation.
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix order-dependent deserialization of `Note` [#274]
+- Bound `TxSkeleton::from_slice` nullifier allocation to reject malformed
+  oversized nullifier counts before allocation.
 
 ### Changed
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.1] - 2026-06-15
+
 ### Fixed
 
 - Preserve compatibility when decoding historical Phoenix transactions after
@@ -485,7 +487,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#61]: https://github.com/dusk-network/phoenix/issues/61
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.35.0...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.35.1...HEAD
+[0.35.1]: https://github.com/dusk-network/phoenix/compare/v0.35.0...v0.35.1
 [0.35.0]: https://github.com/dusk-network/phoenix/compare/v0.34.0...v0.35.0
 [0.34.0]: https://github.com/dusk-network/phoenix/compare/v0.33.1...v0.34.0
 [0.33.1]: https://github.com/dusk-network/phoenix/compare/v0.33.0...v0.33.1

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -9,11 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix order-dependent deserialization of `Note` [#274]
 - Preserve compatibility when decoding historical Phoenix transactions after
   stricter `dusk-jubjub` subgroup checks.
 - Bound `TxSkeleton::from_slice` nullifier allocation to reject malformed
   oversized nullifier counts before allocation.
+
+## [0.35.0] - 2026-02-27
+
+### Fixed
+
+- Fix order-dependent deserialization of `Note` [#274]
 
 ### Changed
 
@@ -21,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move to stable MSRV 1.85
 - Update `dusk-poseidon` to v0.42.0-rc.0
 - Update `jubjub-schnorr` to v0.7.0-rc.0
-- Update `jubjub-elgamal` to v0.5.0-rc.0
+- Update `jubjub-elgamal` to v0.5.0
 
 ## [0.34.0] - 2024-02-07
 
@@ -480,7 +485,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#61]: https://github.com/dusk-network/phoenix/issues/61
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.34.0...HEAD
+[Unreleased]: https://github.com/dusk-network/phoenix/compare/v0.35.0...HEAD
+[0.35.0]: https://github.com/dusk-network/phoenix/compare/v0.34.0...v0.35.0
 [0.34.0]: https://github.com/dusk-network/phoenix/compare/v0.33.1...v0.34.0
 [0.33.1]: https://github.com/dusk-network/phoenix/compare/v0.33.0...v0.33.1
 [0.33.0]: https://github.com/dusk-network/phoenix/compare/v0.32.0...v0.33.0

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.35.0-rc.0"
+version = "0.35.0"
 repository = "https://github.com/dusk-network/phoenix/core"
 description = "Core types and functionalities for Phoenix, a privacy-preserving ZKP-based transaction model"
 exclude = [".github/workflows/dusk-ci.yml", ".gitignore"]
@@ -18,7 +18,7 @@ dusk-jubjub = { version = "0.15", default-features = false, features = [
 ] }
 dusk-poseidon = "0.42.0-rc.0"
 jubjub-schnorr = "0.7.0-rc.0"
-jubjub-elgamal = "0.5.0-rc.0"
+jubjub-elgamal = "0.5.0"
 subtle = { version = "2.6", default-features = false }
 ff = { version = "0.13", default-features = false }
 aes-gcm = { version = "0.10", default-features = false, features = [

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.35.0"
+version = "0.35.1"
 repository = "https://github.com/dusk-network/phoenix/core"
 description = "Core types and functionalities for Phoenix, a privacy-preserving ZKP-based transaction model"
 exclude = [".github/workflows/dusk-ci.yml", ".gitignore"]

--- a/core/Makefile
+++ b/core/Makefile
@@ -17,5 +17,6 @@ no-std: ## Verify no_std compatibility on bare-metal target
 
 clippy: ## Run clippy
 	@cargo clippy --release --features=alloc,serde -- -D warnings
+	@cargo clippy --release --no-default-features -- -D warnings
 
 .PHONY: help test test-no-std no-std clippy

--- a/core/Makefile
+++ b/core/Makefile
@@ -1,0 +1,21 @@
+help: ## Display this help screen
+	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run core tests
+	@cargo test --release --features=alloc,serde
+	@cargo test --release --no-default-features --features=serde
+
+test-no-std: ## Verify no_std compilation
+	@cargo test --release --features=rkyv-impl,alloc --no-run
+	@cargo build --release --no-default-features --features serde --target wasm32-unknown-unknown
+
+no-std: ## Verify no_std compatibility on bare-metal target
+	@rustup target add thumbv6m-none-eabi
+	@cargo build --release --no-default-features --target thumbv6m-none-eabi
+	@cargo build --release --no-default-features --features alloc --target thumbv6m-none-eabi
+
+clippy: ## Run clippy
+	@cargo clippy --release --features=alloc,serde -- -D warnings
+
+.PHONY: help test test-no-std no-std clippy

--- a/core/src/encryption/aes.rs
+++ b/core/src/encryption/aes.rs
@@ -4,15 +4,11 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use aes_gcm::aead::{Aead, AeadCore, KeyInit};
+use aes_gcm::{Aes256Gcm, Key};
 use dusk_jubjub::JubJubAffine;
-use rand::{CryptoRng, RngCore};
-
-use aes_gcm::{
-    Aes256Gcm, Key,
-    aead::{Aead, AeadCore, KeyInit},
-};
-
 use hkdf::Hkdf;
+use rand::{CryptoRng, RngCore};
 use sha2::Sha256;
 
 use crate::Error;

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -4,8 +4,9 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use aes_gcm::Error as AesError;
 use core::fmt;
+
+use aes_gcm::Error as AesError;
 use dusk_bytes::{BadLength, Error as DuskBytesError, InvalidChar};
 
 /// All possible errors for Phoenix's Core

--- a/core/src/keys/public.rs
+++ b/core/src/keys/public.rs
@@ -4,16 +4,16 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::{SecretKey, StealthAddress, ViewKey, keys::hash};
-
-use dusk_jubjub::{JubJubAffine, JubJubExtended, JubJubScalar};
-
+use dusk_bytes::{DeserializableSlice, Error, Serializable};
+use dusk_jubjub::{
+    GENERATOR_EXTENDED, JubJubAffine, JubJubExtended, JubJubScalar,
+};
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize, Serialize};
-
-use dusk_bytes::{DeserializableSlice, Error, Serializable};
-use dusk_jubjub::GENERATOR_EXTENDED;
 use subtle::{Choice, ConstantTimeEq};
+
+use crate::keys::hash;
+use crate::{SecretKey, StealthAddress, ViewKey};
 
 /// Public pair of `a·G` and `b·G` defining a [`PublicKey`]
 #[derive(Debug, Clone, Copy, Eq)]

--- a/core/src/keys/secret.rs
+++ b/core/src/keys/secret.rs
@@ -4,19 +4,18 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::{StealthAddress, keys::hash};
-
+use dusk_bytes::{DeserializableSlice, Error, Serializable};
 use dusk_jubjub::{GENERATOR_EXTENDED, JubJubScalar};
 use ff::Field;
 use jubjub_schnorr::SecretKey as NoteSecretKey;
-use zeroize::Zeroize;
-
+use rand::{CryptoRng, RngCore};
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize, Serialize};
-
-use dusk_bytes::{DeserializableSlice, Error, Serializable};
-use rand::{CryptoRng, RngCore};
 use subtle::{Choice, ConstantTimeEq};
+use zeroize::Zeroize;
+
+use crate::StealthAddress;
+use crate::keys::hash;
 
 /// Secret pair of `a` and `b` defining a [`SecretKey`]
 ///

--- a/core/src/keys/view.rs
+++ b/core/src/keys/view.rs
@@ -4,16 +4,16 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::{SecretKey, StealthAddress, keys::hash};
-
 use dusk_bytes::{DeserializableSlice, Error, Serializable};
 use dusk_jubjub::{
     GENERATOR_EXTENDED, JubJubAffine, JubJubExtended, JubJubScalar,
 };
-use subtle::{Choice, ConstantTimeEq};
-
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize, Serialize};
+use subtle::{Choice, ConstantTimeEq};
+
+use crate::keys::hash;
+use crate::{SecretKey, StealthAddress};
 
 /// Pair of a secret `a` and public `b·G`
 ///

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -25,6 +25,9 @@ mod serde_support;
 /// The number of output notes in a transaction
 pub const OUTPUT_NOTES: usize = 2;
 
+use dusk_jubjub::{
+    GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED, JubJubAffine, JubJubScalar,
+};
 pub use encryption::aes;
 pub use error::Error;
 pub use keys::hash;
@@ -33,14 +36,9 @@ pub use keys::secret::SecretKey;
 pub use keys::view::ViewKey;
 pub use note::{Note, NoteType, Sender, VALUE_ENC_SIZE as NOTE_VAL_ENC_SIZE};
 pub use stealth_address::StealthAddress;
-
 #[cfg(feature = "alloc")]
 /// Transaction Skeleton used by the phoenix transaction model
 pub use transaction::TxSkeleton;
-
-use dusk_jubjub::{
-    GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED, JubJubAffine, JubJubScalar,
-};
 
 /// Use the pedersen commitment scheme to compute a transparent value
 /// commitment.

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -243,10 +243,12 @@ impl Note {
         }
     }
 
+    #[cfg(feature = "alloc")]
     pub(crate) fn read_strict(reader: &mut &[u8]) -> Result<Self, BytesError> {
         Self::from_reader(reader)
     }
 
+    #[cfg(feature = "alloc")]
     pub(crate) fn read_legacy_compat(
         reader: &mut &[u8],
     ) -> Result<Self, BytesError> {
@@ -254,6 +256,7 @@ impl Note {
         Self::from_bytes_legacy_compat(bytes)
     }
 
+    #[cfg(feature = "alloc")]
     pub(crate) fn from_bytes_legacy_compat(
         bytes: &[u8; Self::SIZE],
     ) -> Result<Self, BytesError> {
@@ -686,6 +689,7 @@ impl Sender {
     }
 }
 
+#[cfg(feature = "alloc")]
 fn take_fixed_bytes<'a, const N: usize>(
     reader: &mut &'a [u8],
 ) -> Result<&'a [u8; N], BytesError> {

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -17,6 +17,7 @@ use rand::{CryptoRng, RngCore};
 
 use crate::{
     Error, PublicKey, SecretKey, StealthAddress, ViewKey, aes,
+    stealth_address::affine_from_slice_legacy_compat,
     transparent_value_commitment, value_commitment,
 };
 
@@ -241,6 +242,54 @@ impl Note {
                 [(JubJubAffine::default(), JubJubAffine::default()); 2],
             ),
         }
+    }
+
+    pub(crate) fn read_strict(reader: &mut &[u8]) -> Result<Self, BytesError> {
+        Self::from_reader(reader)
+    }
+
+    pub(crate) fn read_legacy_compat(
+        reader: &mut &[u8],
+    ) -> Result<Self, BytesError> {
+        let bytes = take_fixed_bytes::<SIZE>(reader)?;
+        Self::from_bytes_legacy_compat(bytes)
+    }
+
+    pub(crate) fn from_bytes_legacy_compat(
+        bytes: &[u8; Self::SIZE],
+    ) -> Result<Self, BytesError> {
+        let note_type =
+            bytes[0].try_into().map_err(|_| BytesError::InvalidData)?;
+
+        let mut buf = &bytes[1..];
+        let value_commitment =
+            affine_from_slice_legacy_compat(&buf[..JubJubAffine::SIZE])?;
+        buf = &buf[JubJubAffine::SIZE..];
+
+        let mut stealth_address_bytes = [0u8; StealthAddress::SIZE];
+        stealth_address_bytes.copy_from_slice(&buf[..StealthAddress::SIZE]);
+        let stealth_address =
+            StealthAddress::from_bytes_legacy_compat(&stealth_address_bytes)?;
+        buf = &buf[StealthAddress::SIZE..];
+
+        let pos = u64::from_reader(&mut buf)?;
+
+        let mut value_enc = [0u8; VALUE_ENC_SIZE];
+        value_enc.copy_from_slice(&buf[..VALUE_ENC_SIZE]);
+        buf = &buf[VALUE_ENC_SIZE..];
+
+        let mut sender_bytes = [0u8; Sender::SIZE];
+        sender_bytes.copy_from_slice(&buf[..Sender::SIZE]);
+        let sender = Sender::from_bytes_legacy_compat(&sender_bytes)?;
+
+        Ok(Self {
+            note_type,
+            value_commitment,
+            stealth_address,
+            pos,
+            value_enc,
+            sender,
+        })
     }
 
     fn decrypt_value(
@@ -596,4 +645,56 @@ impl Serializable<{ 1 + 4 * JubJubAffine::SIZE }> for Sender {
 
         Ok(sender)
     }
+}
+
+impl Sender {
+    /// Attempts to convert a byte representation of a sender into a `Sender`,
+    /// accepting historical on-curve `JubJub` points without subgroup checks.
+    pub fn from_bytes_legacy_compat(
+        bytes: &[u8; Self::SIZE],
+    ) -> Result<Self, BytesError> {
+        match bytes[0] {
+            0 => {
+                let mut buf = &bytes[1..];
+                let sender_enc_A_0 = affine_from_slice_legacy_compat(
+                    &buf[..JubJubAffine::SIZE],
+                )?;
+                buf = &buf[JubJubAffine::SIZE..];
+                let sender_enc_A_1 = affine_from_slice_legacy_compat(
+                    &buf[..JubJubAffine::SIZE],
+                )?;
+                buf = &buf[JubJubAffine::SIZE..];
+                let sender_enc_B_0 = affine_from_slice_legacy_compat(
+                    &buf[..JubJubAffine::SIZE],
+                )?;
+                buf = &buf[JubJubAffine::SIZE..];
+                let sender_enc_B_1 = affine_from_slice_legacy_compat(
+                    &buf[..JubJubAffine::SIZE],
+                )?;
+
+                Ok(Sender::Encryption([
+                    (sender_enc_A_0, sender_enc_A_1),
+                    (sender_enc_B_0, sender_enc_B_1),
+                ]))
+            }
+            1 => {
+                let mut contract_data = [0u8; 4 * JubJubAffine::SIZE];
+                contract_data.copy_from_slice(&bytes[1..Self::SIZE]);
+                Ok(Sender::ContractInfo(contract_data))
+            }
+            _ => Err(BytesError::InvalidData),
+        }
+    }
+}
+
+fn take_fixed_bytes<'a, const N: usize>(
+    reader: &mut &'a [u8],
+) -> Result<&'a [u8; N], BytesError> {
+    if reader.len() < N {
+        return Err(BytesError::InvalidData);
+    }
+
+    let (bytes, rest) = reader.split_at(N);
+    *reader = rest;
+    bytes.try_into().map_err(|_| BytesError::InvalidData)
 }

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -14,15 +14,14 @@ use ff::Field;
 use jubjub_elgamal::{DecryptFrom, Encryption as ElGamal};
 use jubjub_schnorr::{PublicKey as NotePublicKey, SecretKey as NoteSecretKey};
 use rand::{CryptoRng, RngCore};
-
-use crate::{
-    Error, PublicKey, SecretKey, StealthAddress, ViewKey, aes,
-    stealth_address::affine_from_slice_legacy_compat,
-    transparent_value_commitment, value_commitment,
-};
-
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize, Serialize};
+
+use crate::stealth_address::affine_from_slice_legacy_compat;
+use crate::{
+    Error, PublicKey, SecretKey, StealthAddress, ViewKey, aes,
+    transparent_value_commitment, value_commitment,
+};
 
 /// Blinder used for transparent notes.
 pub(crate) const TRANSPARENT_BLINDER: JubJubScalar = JubJubScalar::zero();

--- a/core/src/stealth_address.rs
+++ b/core/src/stealth_address.rs
@@ -4,15 +4,12 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use dusk_bytes::{DeserializableSlice, Error, Serializable};
 use dusk_jubjub::{JubJubAffine, JubJubExtended};
 use jubjub_schnorr::PublicKey as NotePublicKey;
-
-use dusk_bytes::{DeserializableSlice, Error, Serializable};
-
-use subtle::{Choice, ConstantTimeEq};
-
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize, Serialize};
+use subtle::{Choice, ConstantTimeEq};
 
 /// To obfuscate the identity of the participants, we utilizes a Stealth Address
 /// system.

--- a/core/src/stealth_address.rs
+++ b/core/src/stealth_address.rs
@@ -55,6 +55,22 @@ impl StealthAddress {
     pub const fn note_pk(&self) -> &NotePublicKey {
         &self.note_pk
     }
+
+    /// Decode a historical stealth address without enforcing subgroup checks
+    /// on the underlying points.
+    pub fn from_bytes_legacy_compat(
+        bytes: &[u8; Self::SIZE],
+    ) -> Result<Self, Error> {
+        let r_affine = affine_from_slice_legacy_compat(&bytes[..32])?;
+        let note_pk_affine = affine_from_slice_legacy_compat(&bytes[32..])?;
+
+        Ok(Self {
+            R: JubJubExtended::from(r_affine),
+            note_pk: NotePublicKey::from_raw_unchecked(JubJubExtended::from(
+                note_pk_affine,
+            )),
+        })
+    }
 }
 
 impl ConstantTimeEq for StealthAddress {
@@ -91,4 +107,13 @@ impl Serializable<64> for StealthAddress {
 
         Ok(StealthAddress { R, note_pk })
     }
+}
+
+pub(crate) fn affine_from_slice_legacy_compat(
+    bytes: &[u8],
+) -> Result<JubJubAffine, Error> {
+    let mut point = [0u8; JubJubAffine::SIZE];
+    point.copy_from_slice(bytes);
+    Option::<JubJubAffine>::from(JubJubAffine::from_bytes(point))
+        .ok_or(Error::InvalidData)
 }

--- a/core/src/transaction.rs
+++ b/core/src/transaction.rs
@@ -10,11 +10,10 @@
 extern crate alloc;
 use alloc::vec::Vec;
 
-#[cfg(feature = "rkyv-impl")]
-use rkyv::{Archive, Deserialize, Serialize};
-
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
+#[cfg(feature = "rkyv-impl")]
+use rkyv::{Archive, Deserialize, Serialize};
 
 use crate::{Note, OUTPUT_NOTES};
 

--- a/core/src/transaction.rs
+++ b/core/src/transaction.rs
@@ -97,8 +97,24 @@ impl TxSkeleton {
         let mut buffer = buf;
         let root = BlsScalar::from_reader(&mut buffer)?;
 
-        let num_nullifiers = u64::from_reader(&mut buffer)?;
-        let mut nullifiers = Vec::with_capacity(num_nullifiers as usize);
+        let num_nullifiers_u64 = u64::from_reader(&mut buffer)?;
+        let min_tail_len = OUTPUT_NOTES
+            .checked_mul(Note::SIZE)
+            .and_then(|len| len.checked_add(u64::SIZE + u64::SIZE))
+            .ok_or(BytesError::InvalidData)?;
+        if buffer.len() < min_tail_len {
+            return Err(BytesError::InvalidData);
+        }
+
+        let max_nullifiers_by_len =
+            (buffer.len() - min_tail_len) / BlsScalar::SIZE;
+        let num_nullifiers = usize::try_from(num_nullifiers_u64)
+            .map_err(|_| BytesError::InvalidData)?;
+        if num_nullifiers > max_nullifiers_by_len {
+            return Err(BytesError::InvalidData);
+        }
+
+        let mut nullifiers = Vec::with_capacity(num_nullifiers);
         for _ in 0..num_nullifiers {
             nullifiers.push(BlsScalar::from_reader(&mut buffer)?);
         }
@@ -140,5 +156,25 @@ impl TxSkeleton {
     /// Returns the deposit of the transaction.
     pub fn deposit(&self) -> u64 {
         self.deposit
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_slice_rejects_unbounded_nullifier_count() {
+        let mut bytes = Vec::new();
+        bytes.extend(BlsScalar::from(0u64).to_bytes());
+        bytes.extend(u64::MAX.to_bytes());
+
+        // Fill enough bytes to pass fixed-tail length checks while keeping the
+        // nullifier count obviously inconsistent with the available payload.
+        let min_tail_len = OUTPUT_NOTES * Note::SIZE + u64::SIZE + u64::SIZE;
+        bytes.resize(BlsScalar::SIZE + u64::SIZE + min_tail_len, 0u8);
+
+        let err = TxSkeleton::from_slice(&bytes).unwrap_err();
+        assert_eq!(err, BytesError::InvalidData);
     }
 }

--- a/core/src/transaction.rs
+++ b/core/src/transaction.rs
@@ -49,6 +49,54 @@ pub struct TxSkeleton {
 }
 
 impl TxSkeleton {
+    fn from_slice_with(
+        buf: &[u8],
+        read_note: fn(&mut &[u8]) -> Result<Note, BytesError>,
+    ) -> Result<Self, BytesError> {
+        let mut buffer = buf;
+        let root = BlsScalar::from_reader(&mut buffer)?;
+
+        let num_nullifiers_u64 = u64::from_reader(&mut buffer)?;
+        let min_tail_len = OUTPUT_NOTES
+            .checked_mul(Note::SIZE)
+            .and_then(|len| len.checked_add(u64::SIZE + u64::SIZE))
+            .ok_or(BytesError::InvalidData)?;
+        if buffer.len() < min_tail_len {
+            return Err(BytesError::InvalidData);
+        }
+
+        let max_nullifiers_by_len =
+            (buffer.len() - min_tail_len) / BlsScalar::SIZE;
+        let num_nullifiers = usize::try_from(num_nullifiers_u64)
+            .map_err(|_| BytesError::InvalidData)?;
+        if num_nullifiers > max_nullifiers_by_len {
+            return Err(BytesError::InvalidData);
+        }
+
+        let mut nullifiers = Vec::with_capacity(num_nullifiers);
+        for _ in 0..num_nullifiers {
+            nullifiers.push(BlsScalar::from_reader(&mut buffer)?);
+        }
+
+        let mut outputs = Vec::with_capacity(OUTPUT_NOTES);
+        for _ in 0..OUTPUT_NOTES {
+            outputs.push(read_note(&mut buffer)?);
+        }
+        let outputs: [Note; OUTPUT_NOTES] =
+            outputs.try_into().map_err(|_| BytesError::InvalidData)?;
+
+        let max_fee = u64::from_reader(&mut buffer)?;
+        let deposit = u64::from_reader(&mut buffer)?;
+
+        Ok(Self {
+            root,
+            nullifiers,
+            outputs,
+            max_fee,
+            deposit,
+        })
+    }
+
     /// Return input bytes to a hash function for the transaction.
     #[must_use]
     pub fn to_hash_input_bytes(&self) -> Vec<u8> {
@@ -94,48 +142,13 @@ impl TxSkeleton {
 
     /// Deserialize the transaction from a bytes buffer.
     pub fn from_slice(buf: &[u8]) -> Result<Self, BytesError> {
-        let mut buffer = buf;
-        let root = BlsScalar::from_reader(&mut buffer)?;
+        Self::from_slice_with(buf, Note::read_strict)
+    }
 
-        let num_nullifiers_u64 = u64::from_reader(&mut buffer)?;
-        let min_tail_len = OUTPUT_NOTES
-            .checked_mul(Note::SIZE)
-            .and_then(|len| len.checked_add(u64::SIZE + u64::SIZE))
-            .ok_or(BytesError::InvalidData)?;
-        if buffer.len() < min_tail_len {
-            return Err(BytesError::InvalidData);
-        }
-
-        let max_nullifiers_by_len =
-            (buffer.len() - min_tail_len) / BlsScalar::SIZE;
-        let num_nullifiers = usize::try_from(num_nullifiers_u64)
-            .map_err(|_| BytesError::InvalidData)?;
-        if num_nullifiers > max_nullifiers_by_len {
-            return Err(BytesError::InvalidData);
-        }
-
-        let mut nullifiers = Vec::with_capacity(num_nullifiers);
-        for _ in 0..num_nullifiers {
-            nullifiers.push(BlsScalar::from_reader(&mut buffer)?);
-        }
-
-        let mut outputs = Vec::with_capacity(OUTPUT_NOTES);
-        for _ in 0..OUTPUT_NOTES {
-            outputs.push(Note::from_reader(&mut buffer)?);
-        }
-        let outputs: [Note; OUTPUT_NOTES] =
-            outputs.try_into().map_err(|_| BytesError::InvalidData)?;
-
-        let max_fee = u64::from_reader(&mut buffer)?;
-        let deposit = u64::from_reader(&mut buffer)?;
-
-        Ok(Self {
-            root,
-            nullifiers,
-            outputs,
-            max_fee,
-            deposit,
-        })
+    /// Deserialize the transaction from a bytes buffer, accepting historical
+    /// on-curve `JubJub` points inside output notes.
+    pub fn from_slice_legacy_compat(buf: &[u8]) -> Result<Self, BytesError> {
+        Self::from_slice_with(buf, Note::read_legacy_compat)
     }
 
     /// Returns the inputs to the transaction.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,6 @@
 max_width = 80
+unstable_features = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
+use_field_init_shorthand = true
+wrap_comments = true


### PR DESCRIPTION
## Summary

- merge Phoenix private maintenance history through `5d1934dcff8a4ba9bd365b8a6772a596681b1500`
- includes the Rusk 1.7 pinned private commit `68d48a1d6ad124bfd17b6d4770f6308778422d02`
- release `phoenix-core 0.35.1` and `phoenix-circuits 0.8.1`
- update circuits to depend on `phoenix-core 0.35.1` and `dusk-plonk 0.22.1`

## Notes

This keeps Rusk on the Phoenix 0.35/0.8 line while replacing the private git dependency with public patch releases.

## Validation

- `cargo package -p phoenix-core --allow-dirty --no-verify`
- `make cq`
- `make test`
- `make test-no-std`
- `make no-std`

`phoenix-circuits` packaging must be rerun after `phoenix-core 0.35.1` is published, because crates.io cannot resolve that dependency before publication.